### PR TITLE
Ignore `last_modified` timestamp deciding whether to do an update (fixes #6)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,9 @@ resource "aws_lambda_function" "notify_slack" {
   }
 
   lifecycle {
-    ignore_changes = ["filename"]
+    ignore_changes = [
+      "filename",
+      "last_modified",
+    ]
   }
 }


### PR DESCRIPTION
The `last_modified` timestamp is tied to when a user did a `terraform init`. This means the exact same code, checked out at different times, results in a change being detected. Ignoring the timestamp fixes this.

Changes to the function will still be detected like:

```
  ~ module.notify_slack_alerts.aws_lambda_function.notify_slack
      source_code_hash:                 "Y8yIL83IwWZAe4hqFlfZnXIkK27kRDm1ihkbsy9vuek=" => "U4ExxA5bGa7s1wQxb3uHUZTZZ3ONTd85Ba4DMYk7DqI="
```
