### PR TITLE
Correct notify_slack.py msg and remove lifecycle ignore_changes from …

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -72,7 +72,7 @@ def notify_slack(message, region):
 
 
 def lambda_handler(event, context):
-    message = json.loads(event['Records'][0]['Sns']['Message'])
+    message = event['Records'][0]['Sns']['Message']
     region = event['Records'][0]['Sns']['TopicArn'].split(":")[3]
     notify_slack(message, region)
 

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ resource "aws_lambda_permission" "sns_notify_slack" {
 
 data "archive_file" "notify_slack" {
   type        = "zip"
+
   source_file = "${path.module}/functions/notify_slack.py"
   output_path = "${path.module}/functions/notify_slack.zip"
 }
@@ -51,12 +52,5 @@ resource "aws_lambda_function" "notify_slack" {
       SLACK_USERNAME    = "${var.slack_username}"
       SLACK_EMOJI       = "${var.slack_emoji}"
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      "filename",
-      "last_modified",
-    ]
   }
 }


### PR DESCRIPTION
When applying, originally saw the following error message in CloudWatch when running the lambda function.
```
Expecting value: line 1 column 1 (char 0): JSONDecodeError
Traceback (most recent call last):
File "/var/task/notify_slack.py", line 75, in lambda_handler
message = json.loads(event['Records'][0]['Sns']['Message'])
File "/var/lang/lib/python3.6/json/__init__.py", line 354, in loads
return _default_decoder.decode(s)
File "/var/lang/lib/python3.6/json/decoder.py", line 339, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "/var/lang/lib/python3.6/json/decoder.py", line 357, in raw_decode
raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Also, when switching the module source from the terraform module repository source location, `terraform-aws-modules/notify-slack/aws`, to this fork, `github.com/nutrienrob/terraform-aws-notify-slack.git`, the following error was seen in terraform as the appropriate updates were not happening.
```
* module.foo.aws_lambda_function.notify_slack: 1 error(s) occurred:
* aws_lambda_function.notify_slack: Unable to load "/terraform/.terraform/modules/c05689c7d2a45375e2d2e872cc29412f/terraform-aws-modules-terraform-aws-notify-slack-969628e/functions/notify_slack.zip": open /terraform/.terraform/modules/c05689c7d2a45375e2d2e872cc29412f/terraform-aws-modules-terraform-aws-notify-slack-969628e/functions/notify_slack.zip: no such file or directory
```

These changes correct both issues.