### PR TITLE
include short alarm name in slack notification text

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -60,8 +60,9 @@ def notify_slack(message, region):
         "attachments": []
     }
     if "AlarmName" in message:
-        payload['text'] = "AWS CloudWatch notification"
-        payload['attachments'].append(cloudwatch_notification(message, region))
+        notification = cloudwatch_notification(message, region)
+        payload['text'] = "AWS CloudWatch notification - " + notification['fields'][0]['value']
+        payload['attachments'].append(notification)
     else:
         payload['text'] = "AWS notification"
         payload['attachments'].append(default_notification(message))

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -61,7 +61,7 @@ def notify_slack(message, region):
     }
     if "AlarmName" in message:
         notification = cloudwatch_notification(message, region)
-        payload['text'] = "AWS CloudWatch notification - " + notification['fields'][0]['value']
+        payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
         payload['attachments'].append(notification)
     else:
         payload['text'] = "AWS notification"


### PR DESCRIPTION
Provide a bit of context to notifications by including the shortname in the notification text