### PR TITLE
Add flag to enable/disable creation of resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,45 +1,56 @@
 data "aws_sns_topic" "this" {
-  count = "${1 - var.create_sns_topic}"
+  count = "${(1 - var.create_sns_topic) * var.enable}"
 
   name = "${var.sns_topic_name}"
 }
 
 resource "aws_sns_topic" "this" {
-  count = "${var.create_sns_topic}"
+  count = "${var.create_sns_topic * var.enable}"
 
   name = "${var.sns_topic_name}"
 }
 
 locals {
-  sns_topic_arn = "${element(compact(concat(aws_sns_topic.this.*.arn, data.aws_sns_topic.this.*.arn)), 0)}"
+  sns_topic_arn      = "${element(compact(concat(aws_sns_topic.this.*.arn, data.aws_sns_topic.this.*.arn, list(var.enable))), 0)}"
+  function_name_base = "${format("%s-%s", var.lambda_function_name, var.sns_topic_name)}"
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
+  count = "${var.enable}"
+
   topic_arn = "${local.sns_topic_arn}"
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack.arn}"
+  endpoint  = "${aws_lambda_function.notify_slack.0.arn}"
 }
 
 resource "aws_lambda_permission" "sns_notify_slack" {
+  count = "${var.enable}"
+
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack.function_name}"
+  function_name = "${aws_lambda_function.notify_slack.0.function_name}"
   principal     = "sns.amazonaws.com"
   source_arn    = "${local.sns_topic_arn}"
 }
 
 data "archive_file" "notify_slack" {
+  count = "${var.enable}"
+
   type        = "zip"
   source_file = "${path.module}/functions/notify_slack.py"
   output_path = "${path.module}/functions/notify_slack.zip"
 }
 
 resource "aws_lambda_function" "notify_slack" {
-  filename         = "${data.archive_file.notify_slack.output_path}"
-  function_name    = "${var.lambda_function_name}"
+  count = "${var.enable}"
+
+  filename = "${data.archive_file.notify_slack.0.output_path}"
+
+  function_name = "${substr(local.function_name_base, 0, length(local.function_name_base) > 64 ? 64 : length(local.function_name_base))}"
+
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.output_base64sha256}"
+  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
   runtime          = "python3.6"
   timeout          = 30
   kms_key_arn      = "${var.kms_key_arn}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,35 +5,35 @@ output "this_slack_topic_arn" {
 
 output "lambda_iam_role_arn" {
   description = "The ARN of the IAM role used by Lambda function"
-  value       = "${aws_iam_role.lambda.arn}"
+  value       = "${element(concat(aws_iam_role.lambda.*.arn, list("")), 0)}"
 }
 
 output "lambda_iam_role_name" {
   description = "The name of the IAM role used by Lambda function"
-  value       = "${aws_iam_role.lambda.arn}"
+  value       = "${element(concat(aws_iam_role.lambda.*.arn, list("")), 0)}"
 }
 
 output "notify_slack_lambda_function_arn" {
   description = "The ARN of the Lambda function"
-  value       = "${aws_lambda_function.notify_slack.arn}"
+  value       = "${element(concat(aws_lambda_function.notify_slack.*.arn, list("")), 0)}"
 }
 
 output "notify_slack_lambda_function_name" {
   description = "The name of the Lambda function"
-  value       = "${aws_lambda_function.notify_slack.function_name}"
+  value       = "${element(concat(aws_lambda_function.notify_slack.*.function_name, list("")), 0)}"
 }
 
 output "notify_slack_lambda_function_invoke_arn" {
   description = "The ARN to be used for invoking Lambda function from API Gateway"
-  value       = "${aws_lambda_function.notify_slack.invoke_arn}"
+  value       = "${element(concat(aws_lambda_function.notify_slack.*.invoke_arn, list("")), 0)}"
 }
 
 output "notify_slack_lambda_function_last_modified" {
   description = "The date Lambda function was last modified"
-  value       = "${aws_lambda_function.notify_slack.last_modified}"
+  value       = "${element(concat(aws_lambda_function.notify_slack.*.last_modified, list("")), 0)}"
 }
 
 output "notify_slack_lambda_function_version" {
   description = "Latest published version of your Lambda function"
-  value       = "${aws_lambda_function.notify_slack.version}"
+  value       = "${element(concat(aws_lambda_function.notify_slack.*.version, list("")), 0)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,8 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key used for decrypting slack webhook url"
   default     = ""
 }
+
+variable "enable" {
+  description = "Bool to enable or disable the creation of resources."
+  default     = "1"
+}


### PR DESCRIPTION
When this module is used with terraform workspaces we may choose to
enable/disable creation of resources based on various conditions.  Since
terraform modules don't support the count attribute we must pass in the
parameter and apply it to each resource within the module.

Unfortunately we also need to perform magic around various references to
paramaters for each resource when it doesn't get created.  We do this by
applying defaults with a combination of interpolation functions in a
very hacky way.  Not something to be proud of.