### PR TITLE
Fixed bug which causes apply failure when create = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_sns_topic" "this" {
 }
 
 locals {
-  sns_topic_arn = "${element(compact(concat(aws_sns_topic.this.*.arn, data.aws_sns_topic.this.*.arn, list(""))), 0)}"
+  sns_topic_arn = "${element(concat(aws_sns_topic.this.*.arn, data.aws_sns_topic.this.*.arn, list("")), 0)}"
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {


### PR DESCRIPTION
The concat operation removes the empty string from the concatenated list, meaning that when create = false, the element operator tries to index into item 0 of a zero length list. This change fixes it so that when create = false, the apply will succeed with an empty value being computed for local.sns_topic_arn