### PR TITLE
Change KMS resource's format to correct form.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda" {
 
     actions = ["kms:Decrypt"]
 
-    resources = ["${var.kms_key_arn == "" ? "" : var.kms_key_arn}"]
+    resources = ["${var.kms_key_arn == "" ? "*" : var.kms_key_arn}"]
   }
 }
 


### PR DESCRIPTION
We should use `"*"` instead of an empty string, otherwise we'll get

```
* module.notify-slack.aws_iam_role_policy.lambda: 1 error(s) occurred:

* aws_iam_role_policy.lambda: Error putting IAM role policy lambda-policy-20180830071013803700000002: MalformedPolicyDocument: Resource  must be in ARN format or "*".
        status code: 400, request id: a3d6068b-ac25-11e8-98f5-79aa2f755c4c
```