### PR TITLE
Issue 21: add switch to enable/disable source hash

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "notify_slack" {
 
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = "${var.use_source_hash ? data.archive_file.notify_slack.0.output_base64sha256 : ""}"
   runtime          = "python3.6"
   timeout          = 30
   kms_key_arn      = "${var.kms_key_arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,8 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key used for decrypting slack webhook url"
   default     = ""
 }
+
+variable "use_source_hash" {
+  description = "Turn on/off zip file hash check - Issue 21"
+  default     = true
+}


### PR DESCRIPTION
Plan shows a change in source code hash even though nothing has changed. As this module doesn't change that often, a lazy fix is to disable using the hash.