### PR TITLE
need to convert from json string to dict when extracting message from event

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -73,7 +73,7 @@ def notify_slack(message, region):
 
 
 def lambda_handler(event, context):
-    message = event['Records'][0]['Sns']['Message']
+    message = json.loads(event['Records'][0]['Sns']['Message'])
     region = event['Records'][0]['Sns']['TopicArn'].split(":")[3]
     notify_slack(message, region)
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -59,6 +59,11 @@ def notify_slack(message, region):
         "icon_emoji": slack_emoji,
         "attachments": []
     }
+    if type(message) is str:
+        try:
+            message = json.loads(message)
+        except json.JSONDecodeError as err:
+            logging.exception(f'JSON decode error: {err}')
     if "AlarmName" in message:
         notification = cloudwatch_notification(message, region)
         payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
@@ -73,7 +78,7 @@ def notify_slack(message, region):
 
 
 def lambda_handler(event, context):
-    message = json.loads(event['Records'][0]['Sns']['Message'])
+    message = event['Records'][0]['Sns']['Message']
     region = event['Records'][0]['Sns']['TopicArn'].split(":")[3]
     notify_slack(message, region)
 


### PR DESCRIPTION
The value of `event['Records'][0]['Sns']['Message']` is a json string, not a dictionary.  I was getting this error prior to making the change:

    string indices must be integers: TypeError
    Traceback (most recent call last):
    File "/var/task/notify_slack.py", line 79, in lambda_handler
    notify_slack(subject, message, region)
    File "/var/task/notify_slack.py", line 64, in notify_slack
    payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
    TypeError: string indices must be integers