### PR TITLE
Use urllib.parse.quote for the alarm name

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -29,7 +29,7 @@ def cloudwatch_notification(message, region):
                 { "title": "Current State", "value": message['NewStateValue'], "short": True },
                 {
                     "title": "Link to Alarm",
-                    "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + urllib.parse.quote_plus(message['AlarmName']),
+                    "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + urllib.parse.quote(message['AlarmName']),
                     "short": False
                 }
             ]


### PR DESCRIPTION
# Description

Alarm names with spaces produce links that are not recognized by the AWS console:

<img width="734" alt="quote_plus" src="https://user-images.githubusercontent.com/11336/59151256-34c68700-8a30-11e9-8a0a-f8c1d8f68973.png">


Method [`#quote_plus`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus) replace spaces by plus sign which AWS does not recognize. Using [`#quote`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) replaces spaces with percent escaping (`%20`).
