### PR TITLE
Add the option to reserve concurrency on Lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you want to subscribe AWS Lambda Function created by this module to an existi
 | create_sns_topic | Whether to create new SNS topic | string | `true` | no |
 | kms_key_arn | ARN of the KMS key used for decrypting slack webhook url | string | `` | no |
 | lambda_function_name | The name of the Lambda function to create | string | `notify_slack` | no |
+| lambda_reserved_concurrency | The number of reserved concurrent Lambda executions | `-1` | no |
 | slack_channel | The name of the channel in Slack for notifications | string | - | yes |
 | slack_emoji | A custom emoji that will appear on Slack messages | string | `:aws:` | no |
 | slack_username | The username that will appear on Slack messages | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -66,12 +66,13 @@ resource "aws_lambda_function" "notify_slack" {
 
   function_name = var.lambda_function_name
 
-  role             = aws_iam_role.lambda[0].arn
-  handler          = "notify_slack.lambda_handler"
-  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
-  runtime          = "python3.6"
-  timeout          = 30
-  kms_key_arn      = var.kms_key_arn
+  role                            = aws_iam_role.lambda[0].arn
+  handler                         = "notify_slack.lambda_handler"
+  source_code_hash                = data.archive_file.notify_slack[0].output_base64sha256
+  runtime                         = "python3.6"
+  timeout                         = 30
+  kms_key_arn                     = var.kms_key_arn
+  reserved_concurrent_executions  = var.lambda_reserved_concurrency
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "lambda_function_name" {
   default     = "notify_slack"
 }
 
+variable "lambda_reserved_concurrency" {
+  description = "The number of reserved concurrent Lambda executions"
+  type        = number
+  default     = -1
+}
+
 variable "sns_topic_name" {
   description = "The name of the SNS topic to create"
   type        = string


### PR DESCRIPTION
# Add option to reserve lambda concurrency

Add the option to reserve a specific number of concurrent executions for the slack notifying lambda.

This was identified as a useful feature in order to notify slack even when other lambdas are using all of the account's available concurrency.