### PR TITLE
Create AWS Cloudwatch log group and give explicit access to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ module "notify_slack" {
 
 If you want to subscribe AWS Lambda Function created by this module to an existing SNS topic you should specify `create_sns_topic = false` as argument and specify name of existing SNS topic name in `sns_topic_name`.
 
+## Import existing Cloudwatch Log Group
+
+Since `v2.3.0` of this module AWS Cloudwatch Log group is created also by this module.
+
+If you are updating from previous version of this module and you don't want to recreate log group, you need to import it like this (change `MODULE_NAME` as necessary):
+
+```
+$ terraform import module.MODULE_NAME.aws_cloudwatch_log_group.lambda /aws/lambda/notify_slack
+``` 
+
 ## Examples
 
 * [notify-slack-simple](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/tree/master/examples/notify-slack-simple) - Creates SNS topic which sends messages to Slack channel.
@@ -49,13 +59,15 @@ If you want to subscribe AWS Lambda Function created by this module to an existi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| cloudwatch\_log\_group\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data for Lambda | string | `"null"` | no |
+| cloudwatch\_log\_group\_retention\_in\_days | Specifies the number of days you want to retain log events in log group for Lambda. | number | `"0"` | no |
+| cloudwatch\_log\_group\_tags | Additional tags for the Cloudwatch log group | map(string) | `{}` | no |
 | create | Whether to create all resources | bool | `"true"` | no |
 | create\_sns\_topic | Whether to create new SNS topic | bool | `"true"` | no |
 | iam\_role\_tags | Additional tags for the IAM role | map(string) | `{}` | no |
 | kms\_key\_arn | ARN of the KMS key used for decrypting slack webhook url | string | `""` | no |
 | lambda\_function\_name | The name of the Lambda function to create | string | `"notify_slack"` | no |
 | lambda\_function\_tags | Additional tags for the Lambda function | map(string) | `{}` | no |
-| lambda\_log\_retention | Number of days to retain logs in Cloudwatch | number | `"30"` | no |
 | reserved\_concurrent\_executions | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | number | `"-1"` | no |
 | slack\_channel | The name of the channel in Slack for notifications | string | n/a | yes |
 | slack\_emoji | A custom emoji that will appear on Slack messages | string | `":aws:"` | no |
@@ -69,6 +81,7 @@ If you want to subscribe AWS Lambda Function created by this module to an existi
 
 | Name | Description |
 |------|-------------|
+| lambda\_cloudwatch\_log\_group\_arn | The Amazon Resource Name (ARN) specifying the log group |
 | lambda\_iam\_role\_arn | The ARN of the IAM role used by Lambda function |
 | lambda\_iam\_role\_name | The name of the IAM role used by Lambda function |
 | notify\_slack\_lambda\_function\_arn | The ARN of the Lambda function |

--- a/examples/notify-slack-simple/README.md
+++ b/examples/notify-slack-simple/README.md
@@ -23,6 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Description |
 |------|-------------|
+| lambda\_cloudwatch\_log\_group\_arn | The Amazon Resource Name (ARN) specifying the log group |
 | lambda\_iam\_role\_arn | The ARN of the IAM role used by Lambda function |
 | lambda\_iam\_role\_name | The name of the IAM role used by Lambda function |
 | notify\_slack\_lambda\_function\_arn | The ARN of the Lambda function |

--- a/examples/notify-slack-simple/outputs.tf
+++ b/examples/notify-slack-simple/outputs.tf
@@ -37,3 +37,8 @@ output "notify_slack_lambda_function_version" {
   description = "Latest published version of your Lambda function"
   value       = module.notify_slack.notify_slack_lambda_function_version
 }
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = module.notify_slack.lambda_cloudwatch_log_group_arn
+}

--- a/iam.tf
+++ b/iam.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "lambda_basic" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:*"]
+    resources = ["${aws_cloudwatch_log_group.lambda.arn}"]
   }
 }
 
@@ -68,4 +68,3 @@ resource "aws_iam_role_policy" "lambda" {
     0,
   )
 }
-

--- a/iam.tf
+++ b/iam.tf
@@ -22,7 +22,6 @@ data "aws_iam_policy_document" "lambda_basic" {
     effect = "Allow"
 
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]

--- a/iam.tf
+++ b/iam.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "lambda_basic" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["${aws_cloudwatch_log_group.lambda.arn}"]
+    resources = [aws_cloudwatch_log_group.lambda[0].arn]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,11 @@ locals {
   )
 }
 
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = var.lambda_log_retention
+}
+
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
   count = var.create ? 1 : 0
 
@@ -88,5 +93,6 @@ resource "aws_lambda_function" "notify_slack" {
       last_modified,
     ]
   }
-}
 
+  depends_on = ["aws_cloudwatch_log_group.lambda"]
+}

--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,13 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {
+  count = var.create ? 1 : 0
+
   name              = "/aws/lambda/${var.lambda_function_name}"
-  retention_in_days = var.lambda_log_retention
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
+
+  tags = merge(var.tags, var.cloudwatch_log_group_tags)
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
@@ -90,14 +95,14 @@ resource "aws_lambda_function" "notify_slack" {
     }
   }
 
+  tags = merge(var.tags, var.lambda_function_tags)
+
   lifecycle {
     ignore_changes = [
       filename,
       last_modified,
     ]
   }
-
-  tags = merge(var.tags, var.lambda_function_tags)
 
   depends_on = ["aws_cloudwatch_log_group.lambda"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,3 +38,7 @@ output "notify_slack_lambda_function_version" {
   value       = element(concat(aws_lambda_function.notify_slack.*.version, [""]), 0)
 }
 
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = element(concat(aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,8 @@ variable "kms_key_arn" {
   default     = ""
 }
 
+variable "lambda_log_retention" {
+  description = "Number of days to retain logs in Cloudwatch"
+  type        = number
+  default     = 30
+}

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "reserved_concurrent_executions" {
   default     = -1
 }
 
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Specifies the number of days you want to retain log events in log group for Lambda."
+  type        = number
+  default     = 0
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "The ARN of the KMS Key to use when encrypting log data for Lambda"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
@@ -78,8 +90,8 @@ variable "sns_topic_tags" {
   default     = {}
 }
 
-variable "lambda_log_retention" {
-  description = "Number of days to retain logs in Cloudwatch"
-  type        = number
-  default     = 30
+variable "cloudwatch_log_group_tags" {
+  description = "Additional tags for the Cloudwatch log group"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
# Description

The resources deployed by this module mimics the experience when creating Lambda functions in the console. The function gets created with an IAM role attached which allows it to put logs and create groups/streams anywhere; even places it's not supposed to. When the function creates the log group with it's built-in permissions this happens outside of Terraform. When you destroy the module a log group will remain and become stale because it's never tracked by Terraform's state in this way.

This PR adds a Cloudwatch Logs group and adds an explicit dependency on the function so that it will only be created when the log group is made (to prevent a race condition). It also adjusts the policy of the function to explicitly allow only log events on the Terraform managed log group.