### PR TITLE
Reduce scope of IAM Policy for CloudWatch Logs

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "lambda_basic" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:*"]
+    resources = ["arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}*"]
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "lambda_basic" {
 
     resources = [
       "arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}",
-      "arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}:log-stream:*",
+      "arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}:*",
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -27,7 +27,10 @@ data "aws_iam_policy_document" "lambda_basic" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}*"]
+    resources = [
+      "arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}",
+      "arn:aws:logs:*:*:/aws/lambda/${var.lambda_function_name}:log-stream:*",
+    ]
   }
 }
 


### PR DESCRIPTION
The IAM policy for the Lambda was *:*:* which seems like it was more permissive than necessary.  This PR will reduce the scope to having the wildcard "${var.lambda_function_name}:log-stream:*" instead of all Cloudwatch logs.  This should be a non-breaking change that has been tested with Terraform 0.11.14.
