### PR TITLE
Add support for resource tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,17 @@ If you want to subscribe AWS Lambda Function created by this module to an existi
 |------|-------------|:----:|:-----:|:-----:|
 | create | Whether to create all resources | string | `true` | no |
 | create_sns_topic | Whether to create new SNS topic | string | `true` | no |
+| iam_role_tags | Additional tags for the IAM role | map(string) | `{}` | no |
 | kms_key_arn | ARN of the KMS key used for decrypting slack webhook url | string | `` | no |
 | lambda_function_name | The name of the Lambda function to create | string | `notify_slack` | no |
+| lambda_function_tags | Additional tags for the Lambda function | map(string) | `{}` | no |
 | slack_channel | The name of the channel in Slack for notifications | string | - | yes |
 | slack_emoji | A custom emoji that will appear on Slack messages | string | `:aws:` | no |
 | slack_username | The username that will appear on Slack messages | string | - | yes |
 | slack_webhook_url | The URL of Slack webhook | string | - | yes |
 | sns_topic_name | The name of the SNS topic to create | string | - | yes |
+| sns_topic_tags | Additional tags for the SNS topic | map(string) | `{}` | no |
+| tags | A map of tags to add to all resources | map(string) | `{}` | no |
 
 ## Outputs
 

--- a/iam.tf
+++ b/iam.tf
@@ -52,6 +52,8 @@ resource "aws_iam_role" "lambda" {
 
   name_prefix        = "lambda"
   assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
+
+  tags = merge(var.tags, var.iam_role_tags)
 }
 
 resource "aws_iam_role_policy" "lambda" {

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ resource "aws_sns_topic" "this" {
   count = var.create_sns_topic && var.create ? 1 : 0
 
   name = var.sns_topic_name
+
+  tags = merge(var.tags, var.sns_topic_tags)
 }
 
 locals {
@@ -88,5 +90,7 @@ resource "aws_lambda_function" "notify_slack" {
       last_modified,
     ]
   }
+
+  tags = merge(var.tags, var.lambda_function_tags)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,26 @@ variable "kms_key_arn" {
   default     = ""
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iam_role_tags" {
+  description = "Additional tags for the IAM role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_function_tags" {
+  description = "Additional tags for the Lambda function"
+  type        = map(string)
+  default     = {}
+}
+
+variable "sns_topic_tags" {
+  description = "Additional tags for the SNS topic"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
# Description

The organization I work for requires that we tag all of our AWS resources, so I'd love to get tags wired up for this module! Otherwise, we'll have to fork it 😉 

I pretty much just copied what you have here: https://github.com/terraform-aws-modules/terraform-aws-vpc.