### PR TITLE
Allow custom attachments

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -68,9 +68,8 @@ def notify_slack(subject, message, region):
         notification = cloudwatch_notification(message, region)
         payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
         payload['attachments'].append(notification)
-    elif "attachments" in message:
-        payload['text'] = message.get('text', 'AWS notification')
-        payload['attachments'] = message['attachments']
+    elif "attachments" in message or "text" in message:
+        payload = {**payload, **message}
     else:
         payload['text'] = "AWS notification"
         payload['attachments'].append(default_notification(subject, message))

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -68,6 +68,9 @@ def notify_slack(subject, message, region):
         notification = cloudwatch_notification(message, region)
         payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
         payload['attachments'].append(notification)
+    elif "attachments" in message:
+        payload['text'] = message.get('text', 'AWS notification')
+        payload['attachments'] = message['attachments']
     else:
         payload['text'] = "AWS notification"
         payload['attachments'].append(default_notification(subject, message))


### PR DESCRIPTION
# Description

I would like to control custom attachments. This should be nearly fully backward compatible (edge case is those consumers that are passing an `attachments` or `text` attribute in there json formatted sns message but expecting it to appear as serialized json). If an `attachments` or `text`  attribute is in the message it is assumed it is a well-formed Slack incoming webhook message per these constraints:
https://api.slack.com/docs/message-attachments

This will allow me to format custom messages with links, colors, etc.