### PR TITLE
Removing double json.dumps breaking new line messages

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -39,7 +39,7 @@ def cloudwatch_notification(message, region):
 def default_notification(subject, message):
     return {
             "fallback": "A new message",
-            "fields": [{"title": subject if subject else "Message", "value": json.dumps(message), "short": False}]
+            "fields": [{"title": subject if subject else "Message", "value": message, "short": False}]
         }
 
 


### PR DESCRIPTION
# Description

 With the current code messages that have newlines `\n` break formatting with the double `json.dumps()`. Existing issue https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/37 shows an example of this.

The fix is to remove the double dump as the payload is dumped https://github.com/terraform-aws-modules/terraform-aws-notify-slack/blob/master/functions/notify_slack.py#L75 before sending to Slack.

We have tested this in our own environment for over a week with no issues and frequent daily messages from various sources including AWS CW alerts.

I am happy to test further or add a toggle via an envar to turn on and off this setting to maintain backwards compatibility if there is a case where this change breaks existing functionally.
