### PR TITLE
Include the updated CloudWatch status in the slack text.

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -69,7 +69,7 @@ def notify_slack(subject, message, region):
 
   if "AlarmName" in message:
     notification = cloudwatch_notification(message, region)
-    payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
+    payload['text'] = "AWS CloudWatch notification - " + message['NewStateValue'] + ": " + message['AlarmName']
     payload['attachments'].append(notification)
   else:
     payload['text'] = "AWS notification"


### PR DESCRIPTION
This would make it more useful when using slack on a mobile phone and just checking notifications. Otherwise you have to open slack and check the message itself.

Also it makes it more like the email notification.