### PR TITLE
Allow passing an SNS topic directly to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,32 +88,10 @@ To run the tests:
 | slack\_emoji | A custom emoji that will appear on Slack messages | `string` | `":aws:"` | no |
 | slack\_username | The username that will appear on Slack messages | `string` | n/a | yes |
 | slack\_webhook\_url | The URL of Slack webhook | `string` | n/a | yes |
-| sns\_topic\_name | The name of the SNS topic to create | `string` | n/a | yes |
+| sns\_topic | The existing SNS topic | <pre>object({<br>    arn  = string<br>    name = string<br>  })<br></pre> | <pre>{<br>  "arn": "",<br>  "name": ""<br>}<br></pre> | no |
+| sns\_topic\_name | The name of the SNS topic to create | `string` | `""` | no |
 | sns\_topic\_tags | Additional tags for the SNS topic | `map(string)` | `{}` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
-=======
-|------|-------------|:----:|:-----:|:-----:|
-| cloudwatch\_log\_group\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data for Lambda | string | `"null"` | no |
-| cloudwatch\_log\_group\_retention\_in\_days | Specifies the number of days you want to retain log events in log group for Lambda. | number | `"0"` | no |
-| cloudwatch\_log\_group\_tags | Additional tags for the Cloudwatch log group | map(string) | `{}` | no |
-| create | Whether to create all resources | bool | `"true"` | no |
-| create\_sns\_topic | Whether to create new SNS topic | bool | `"true"` | no |
-| iam\_role\_tags | Additional tags for the IAM role | map(string) | `{}` | no |
-| kms\_key\_arn | ARN of the KMS key used for decrypting slack webhook url | string | `""` | no |
-| lambda\_description | The description of the Lambda function | string | `"null"` | no |
-| lambda\_function\_name | The name of the Lambda function to create | string | `"notify_slack"` | no |
-| lambda\_function\_tags | Additional tags for the Lambda function | map(string) | `{}` | no |
-| log\_events | Boolean flag to enabled/disable logging of incoming events | string | `"false"` | no |
-| reserved\_concurrent\_executions | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | number | `"-1"` | no |
-| slack\_channel | The name of the channel in Slack for notifications | string | n/a | yes |
-| slack\_emoji | A custom emoji that will appear on Slack messages | string | `":aws:"` | no |
-| slack\_username | The username that will appear on Slack messages | string | n/a | yes |
-| slack\_webhook\_url | The URL of Slack webhook | string | n/a | yes |
-| sns\_topic | The existing SNS topic | object | `{ "arn": "", "name": "" }` | no |
-| sns\_topic\_name | The name of the SNS topic to create | string | `""` | no |
-| sns\_topic\_tags | Additional tags for the SNS topic | map(string) | `{}` | no |
-| tags | A map of tags to add to all resources | map(string) | `{}` | no |
-
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ To run the tests:
 | sns\_topic\_name | The name of the SNS topic to create | `string` | n/a | yes |
 | sns\_topic\_tags | Additional tags for the SNS topic | `map(string)` | `{}` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
+=======
+|------|-------------|:----:|:-----:|:-----:|
+| cloudwatch\_log\_group\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data for Lambda | string | `"null"` | no |
+| cloudwatch\_log\_group\_retention\_in\_days | Specifies the number of days you want to retain log events in log group for Lambda. | number | `"0"` | no |
+| cloudwatch\_log\_group\_tags | Additional tags for the Cloudwatch log group | map(string) | `{}` | no |
+| create | Whether to create all resources | bool | `"true"` | no |
+| create\_sns\_topic | Whether to create new SNS topic | bool | `"true"` | no |
+| iam\_role\_tags | Additional tags for the IAM role | map(string) | `{}` | no |
+| kms\_key\_arn | ARN of the KMS key used for decrypting slack webhook url | string | `""` | no |
+| lambda\_description | The description of the Lambda function | string | `"null"` | no |
+| lambda\_function\_name | The name of the Lambda function to create | string | `"notify_slack"` | no |
+| lambda\_function\_tags | Additional tags for the Lambda function | map(string) | `{}` | no |
+| log\_events | Boolean flag to enabled/disable logging of incoming events | string | `"false"` | no |
+| reserved\_concurrent\_executions | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | number | `"-1"` | no |
+| slack\_channel | The name of the channel in Slack for notifications | string | n/a | yes |
+| slack\_emoji | A custom emoji that will appear on Slack messages | string | `":aws:"` | no |
+| slack\_username | The username that will appear on Slack messages | string | n/a | yes |
+| slack\_webhook\_url | The URL of Slack webhook | string | n/a | yes |
+| sns\_topic | The existing SNS topic | object | `{ "arn": "", "name": "" }` | no |
+| sns\_topic\_name | The name of the SNS topic to create | string | `""` | no |
+| sns\_topic\_tags | Additional tags for the SNS topic | map(string) | `{}` | no |
+| tags | A map of tags to add to all resources | map(string) | `{}` | no |
+
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,19 @@ variable "lambda_description" {
 variable "sns_topic_name" {
   description = "The name of the SNS topic to create"
   type        = string
+  default     = ""
+}
+
+variable "sns_topic" {
+  description = "The existing SNS topic"
+  type = object({
+    arn  = string
+    name = string
+  })
+  default = {
+    arn  = ""
+    name = ""
+  }
 }
 
 variable "slack_webhook_url" {


### PR DESCRIPTION
Per https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/46

There has been a change of behavior in how data source work in terraform 0.12 and in this module it prevents us from passing in an yet to be created SNS topic that is managed outside of the module. The good news is Terraform 0.12 support passing in objects as variable and thus we can pass in the sns_topic object directly into this module. 

I tested by provisioning the sns topic module both within the module

```  hcl
create_sns_topic = true
sns_topic_name  = "dynatest"
```

and outside of the module

```hcl
resource "aws_sns_topic" "dynatest" {
  name = "dynatest"
} 
...
module "notify_slack" {
...
  create_sns_topic = true
  sns_topic        = aws_sns_topic.dynatest
}
```