### PR TITLE
feat: Improved format of Auto Scaling notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+functions/pytest.ini
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,13 +214,9 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-<<<<<<< HEAD
 [Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.13.0...HEAD
 [v2.13.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.12.0...v2.13.0
 [v2.12.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.11.0...v2.12.0
-=======
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.11.0...HEAD
->>>>>>> Add formatting for ASG, fix bug in AlarmName payload
 [v2.11.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.10.0...v2.11.0
 [v2.10.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.9.0...v2.10.0
 [v2.9.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.8.0...v2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 <a name="v2.10.0"></a>
 ## [v2.10.0] - 2020-01-21
 
+- Updated CHANGELOG
 - Updated pre-commit-terraform with terraform-docs 0.8.0 support ([#65](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/65))
 
 
@@ -216,9 +217,13 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
+<<<<<<< HEAD
 [Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.13.0...HEAD
 [v2.13.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.12.0...v2.13.0
 [v2.12.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.11.0...v2.12.0
+=======
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.11.0...HEAD
+>>>>>>> Add formatting for ASG, fix bug in AlarmName payload
 [v2.11.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.10.0...v2.11.0
 [v2.10.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.9.0...v2.10.0
 [v2.9.0]: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v2.8.0...v2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
-
 <a name="v2.13.0"></a>
 ## [v2.13.0] - 2020-03-19
 
 
-
 <a name="v2.12.0"></a>
 ## [v2.12.0] - 2020-03-19
-
 
 
 <a name="v2.11.0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+
 <a name="v2.13.0"></a>
 ## [v2.13.0] - 2020-03-19
 
 
+
 <a name="v2.12.0"></a>
 ## [v2.12.0] - 2020-03-19
+
 
 
 <a name="v2.11.0"></a>
@@ -23,7 +26,6 @@ All notable changes to this project will be documented in this file.
 <a name="v2.10.0"></a>
 ## [v2.10.0] - 2020-01-21
 
-- Updated CHANGELOG
 - Updated pre-commit-terraform with terraform-docs 0.8.0 support ([#65](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/65))
 
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import certifi
 from urllib.error import HTTPError
 import os, boto3, json, base64
 import urllib.request, urllib.parse
@@ -43,6 +44,17 @@ def default_notification(subject, message):
     "fields": [{"title": subject if subject else "Message", "value": json.dumps(message) if type(message) is dict else message, "short": False}]
   }
 
+def asg_notification(message):
+  events = {'autoscaling:EC2_INSTANCE_LAUNCH': 'warning', 'autoscaling:EC2_INSTANCE_TERMINATE': 'warning', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR': 'danger', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR': 'danger'}
+  return {
+    "color": events[message['Event']],
+    "fallback": "ASG Notification triggered",
+    "fields": [
+      {"title": "Event", "value": message['Event'], "short": True },
+      {"title": "StatusCode", "value": message['StatusCode'], "short": True },
+      {"title": "Cause", "value": message['Cause'], "short": False },
+    ]
+  }
 
 # Send a message to a slack channel
 def notify_slack(subject, message, region):
@@ -68,9 +80,11 @@ def notify_slack(subject, message, region):
       logging.exception(f'JSON decode error: {err}')
 
   if "AlarmName" in message:
-    notification = cloudwatch_notification(message, region)
     payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
-    payload['attachments'].append(notification)
+    payload['attachments'].append(cloudwatch_notification(message, region))
+  elif "AutoScalingGroupARN" in message:
+    payload['text'] = "*{0}*: {1}".format(message["AutoScalingGroupName"], message["Description"])
+    payload['attachments'].append(asg_notification(message))
   else:
     payload['text'] = "AWS notification"
     payload['attachments'].append(default_notification(subject, message))
@@ -79,7 +93,7 @@ def notify_slack(subject, message, region):
   req = urllib.request.Request(slack_url)
 
   try:
-    result = urllib.request.urlopen(req, data)
+    result = urllib.request.urlopen(req, data, cafile=certifi.where())
     return json.dumps({"code": result.getcode(), "info": result.info().as_string()})
 
   except HTTPError as e:

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -55,6 +55,31 @@ events = (
       }
     ),
     (
+      {
+        "Records": [
+          {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+            "Sns": {
+              "Type": "Notification",
+              "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+              "TopicArn": "arn:aws:sns:eu-west-2:735598076380:service-updates",
+              "Subject": "Auto Scaling: launch for group \"My-AutoScaling-Group-Name\"",
+              "Message": "{\"Progress\": 50, \"AccountId\": \"123456789012\", \"Description\": \"Launching a new EC2 instance: i-738930393837fa\", \"RequestId\": \"abc123456-6d35-74de-25a5-c6c85ff6a521\", \"EndTime\": \"2020-03-04T16:23:18.101Z\", \"AutoScalingGroupARN\": \"arn:aws:autoscaling:us-east-1:123456789012:autoScalingGroup:abc1abc1-1234-1234-1234-c95217515fed:autoScalingGroupName/my-group-name\", \"ActivityId\": \"abc1abc1-1234-1234-1234-c95217515fed\", \"StartTime\": \"2020-03-04T16:22:46.365Z\", \"Service\": \"AWS Auto Scaling\", \"Time\": \"2020-03-04T16:23:18.101Z\", \"EC2InstanceId\": \"i-738930393837fa\", \"StatusCode\": \"InProgress\", \"StatusMessage\": \"\", \"Details\": {\"Subnet ID\": \"subnet-012345679012\", \"Availability Zone\": \"us-east-1d\"}, \"AutoScalingGroupName\": \"My-AutoScaling-Group-Name\", \"Cause\": \"At 2020-03-04T16:22:44Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 2 to 3.\", \"Event\": \"autoscaling:EC2_INSTANCE_LAUNCH\"}",
+              "Timestamp": "2020-02-12T15:45:24.091Z",
+              "SignatureVersion": "1",
+              "Signature": "WMYdVRN7ECNXMWZ0faRDD4fSfALW5MISB6O//LMd/LeSQYNQ/1eKYEE0PM1SHcH+73T/f/eVHbID/F203VZaGECQTD4LVA4B0DGAEY39LVbWdPTCHIDC6QCBV5ScGFZcROBXMe3UBWWMQAVTSWTE0eP526BFUTecaDFM4b9HMT4NEHWa4A2TA7d888JaVKKdSVNTd4bGS6Q2XFG1MOb652BRAHdARO7A6//2/47JZ5COM6LR0/V7TcOYCBZ20CRF6L5XLU46YYL3I1PNGKbEC1PIeVDVJVPcA17NfUbFXWYBX8LHfM4O7ZbGAPaGffDYLFWM6TX1Y6fQ01OSMc21OdUGV6HQR01e%==",
+              "SigningCertUrl": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-7dd85a2b76adaa8dd603b7a0c9150589.pem",
+              "UnsubscribeUrl": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+              "MessageAttributes": {}
+            }
+          }
+        ]
+      }
+    )
+    ,
+    (
         {
             "AlarmName": "Example",
             "AlarmDescription": "Example alarm description.",

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -2,3 +2,5 @@ boto3
 
 pytest
 pytest-env
+certifi
+


### PR DESCRIPTION
## Description
Added formatting for Auto Scaling Notifications, also noticed that the formatting for `AlarmName` was not using the `notification` so I refactored to match the other formats.

## Motivation and Context
I'm piping notifications for many things into my lambda & want to have pretty messages for them.
You could probably close https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/3 with this PR and your README.md which asks for PRs - would also close https://github.com/terraform-aws-modules/terraform-aws-notify-slack/pull/28 since the author seems to have orphaned the PR.

## Breaking Changes
Note my addition of `import certifi` - this was to get local testing running - should be OK on Lambda IMOP but did not test there.
I think the current version probably has a bug in the formatting of the processing of notifications including the string `AlarmName` which I believe I fixed in this PR.

## How Has This Been Tested?
By publishing messages to my slack as described in the README.md
See PR for my tests - should be basic improvement/refactor - no big changes other than the inclusion of `certifi` - might want to think about that change, but local execution of the test was not possible without it (note that this change is in the `notify_slack.py` file, so would be part of the running production code).

![image](https://user-images.githubusercontent.com/2084598/77090014-93b02800-69d4-11ea-9473-a08bff5a5734.png)
