### PR TITLE
fix: Update require version of aws provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.35"
+    aws = ">= 2.35"
   }
 }


### PR DESCRIPTION
Allow use of new 3.0 provider. 