### PR TITLE
fix: Bump version of lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "1.6.0"
+  version = ">= 1.18.0"
 
   create = var.create
 


### PR DESCRIPTION
## Description
Use lambda module version that supports Terraform 13 and AWS provider 3.x

## Motivation and Context
Fixes #93

## Breaking Changes
N/A

## How Has This Been Tested?
* Ran` pre-commit run -a`
* Ran `terraform init`
* Ran `terraform validate`
