### PR TITLE
fix: Use existing CloudWatch log group to avoid duplication

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,9 +100,10 @@ module "lambda" {
   # Do not use Lambda's policy for cloudwatch logs, because we have to add a policy
   # for KMS conditionally. This way attach_policy_json is always true independenty of
   # the value of presense of KMS. Famous "computed values in count" bug...
-  attach_cloudwatch_logs_policy = false
-  attach_policy_json            = true
-  policy_json                   = element(concat(data.aws_iam_policy_document.lambda[*].json, [""]), 0)
+  attach_cloudwatch_logs_policy     = false
+  attach_policy_json                = true
+  policy_json                       = element(concat(data.aws_iam_policy_document.lambda[*].json, [""]), 0)
+  use_existing_cloudwatch_log_group = true
 
   allowed_triggers = {
     AllowExecutionFromSNS = {

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ module "lambda" {
   attach_cloudwatch_logs_policy     = false
   attach_policy_json                = true
   policy_json                       = element(concat(data.aws_iam_policy_document.lambda[*].json, [""]), 0)
-  use_existing_cloudwatch_log_group = true
+  use_existing_cloudwatch_log_group = aws_cloudwatch_log_group.lambda.name != "" ? true : false
 
   allowed_triggers = {
     AllowExecutionFromSNS = {


### PR DESCRIPTION
## Description
Both this module and terraform-aws-lambda create a CloudWatch log group with the same name but different tags so they get duplicated hence throwing an error on creation.

## Motivation and Context
Fixes #97

## Breaking Changes
N/A

## How Has This Been Tested?
- Ran the usual pre-commit checks
- I've used my fork version and ran a terraform plan which now only creates one CloudWatch log group
