### PR TITLE
fix: Fix regression with aws_cloudwatch_log_group resource after upgrade of AWS provider 3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     sid       = "AllowWriteToCloudwatchLogs"
     effect    = "Allow"
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = [element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)]
+    resources = [replace("${element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)}:*", ":*:*", ":*")]
   }
 
   lambda_policy_document_kms = {


### PR DESCRIPTION
Fixes #105