### PR TITLE
feat: make it possible to use ssm parameters as slack_webhook_url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.43.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ To run the tests:
 | lambda\_description | The description of the Lambda function | `string` | `null` | no |
 | lambda\_function\_name | The name of the Lambda function to create | `string` | `"notify_slack"` | no |
 | lambda\_function\_tags | Additional tags for the Lambda function | `map(string)` | `{}` | no |
+| lambda\_role | IAM role attached to the Lambda Function.  If this is set then a role will not be created for you. | `string` | `""` | no |
 | log\_events | Boolean flag to enabled/disable logging of incoming events | `bool` | `false` | no |
 | reserved\_concurrent\_executions | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |
 | slack\_channel | The name of the channel in Slack for notifications | `string` | n/a | yes |
 | slack\_emoji | A custom emoji that will appear on Slack messages | `string` | `":aws:"` | no |
 | slack\_username | The username that will appear on Slack messages | `string` | n/a | yes |
 | slack\_webhook\_url | The URL of Slack webhook | `string` | n/a | yes |
+| slack\_webhook\_url\_is\_ssm\_param | Whether slack\_webhook\_url is an ssm parameter | `bool` | `false` | no |
 | sns\_topic\_kms\_key\_id | ARN of the KMS key used for enabling SSE on the topic | `string` | `""` | no |
 | sns\_topic\_name | The name of the SNS topic to create | `string` | n/a | yes |
 | sns\_topic\_tags | Additional tags for the SNS topic | `map(string)` | `{}` | no |

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -47,7 +47,13 @@ def default_notification(subject, message):
 # Send a message to a slack channel
 def notify_slack(subject, message, region):
   slack_url = os.environ['SLACK_WEBHOOK_URL']
-  if not slack_url.startswith("http"):
+  if 'SLACK_WEBHOOK_URL_IS_SSM_PARAM' in os.environ and os.environ['SLACK_WEBHOOK_URL_IS_SSM_PARAM'] == 'True':
+    ssm = boto3.client("ssm")
+    slack_url = ssm.get_parameter(
+      Name=slack_url,
+      WithDecryption=True
+    ).get("Parameter").get("Value")
+  elif not slack_url.startswith("http"):
     slack_url = decrypt(slack_url)
 
   slack_channel = os.environ['SLACK_CHANNEL']

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "slack_webhook_url" {
   type        = string
 }
 
+variable "slack_webhook_url_is_ssm_param" {
+  description = "Whether slack_webhook_url is an ssm parameter"
+  type        = bool
+  default     = false
+}
+
 variable "slack_channel" {
   description = "The name of the channel in Slack for notifications"
   type        = string


### PR DESCRIPTION
## Description
with this change lambda can pick up the url from an ssm parameter.
new variable: slack_webhook_url_is_ssm_param
in case the ssm parameter is encrypted the kms key must also be specified.

## Motivation and Context
make it completely avoidable for the url to appear in the state

## Breaking Changes
none that I know of

## How Has This Been Tested?
already using it in aws
