### PR TITLE
fix: Typo on subscription_filter_policy variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.41.0
+    rev: v1.43.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ All notable changes to this project will be documented in this file.
 <a name="v2.11.0"></a>
 ## [v2.11.0] - 2020-03-19
 
-- Add subsription filter policy support ([#74](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/74))
+- Add subscription filter policy support ([#74](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/74))
 
 
 <a name="v2.10.0"></a>

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ To run the tests:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0, < 0.14 |
-| aws | >= 2.35, < 4.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 2.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.35, < 4.0 |
+| aws | >= 2.35 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To run the tests:
 | sns\_topic\_kms\_key\_id | ARN of the KMS key used for enabling SSE on the topic | `string` | `""` | no |
 | sns\_topic\_name | The name of the SNS topic to create | `string` | n/a | yes |
 | sns\_topic\_tags | Additional tags for the SNS topic | `map(string)` | `{}` | no |
-| subsription\_filter\_policy | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
+| subscription\_filter\_policy | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/cloudwatch-alerts-to-slack/README.md
+++ b/examples/cloudwatch-alerts-to-slack/README.md
@@ -60,14 +60,14 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0, < 0.14 |
-| aws | >= 2.35, < 4.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 2.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.35, < 4.0 |
+| aws | >= 2.35 |
 
 ## Inputs
 

--- a/examples/cloudwatch-alerts-to-slack/versions.tf
+++ b/examples/cloudwatch-alerts-to-slack/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 2.35, < 4.0"
+    aws = ">= 2.35"
   }
 }

--- a/examples/notify-slack-simple/README.md
+++ b/examples/notify-slack-simple/README.md
@@ -23,14 +23,14 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0, < 0.14 |
-| aws | >= 2.35, < 4.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 2.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.35, < 4.0 |
+| aws | >= 2.35 |
 
 ## Inputs
 

--- a/examples/notify-slack-simple/versions.tf
+++ b/examples/notify-slack-simple/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 2.35, < 4.0"
+    aws = ">= 2.35"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
   topic_arn     = local.sns_topic_arn
   protocol      = "lambda"
   endpoint      = module.lambda.this_lambda_function_arn
-  filter_policy = var.subsription_filter_policy
+  filter_policy = var.subscription_filter_policy
 }
 
 module "lambda" {

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "cloudwatch_log_group_tags" {
   default     = {}
 }
 
-variable "subsription_filter_policy" {
+variable "subscription_filter_policy" {
   description = "(Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource."
   type        = string
   default     = null

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 2.35, < 4.0"
+    aws = ">= 2.35"
   }
 }


### PR DESCRIPTION
## Description
Resolving the typo in the input parameter name: `subsription_filter_policy` as described in the issue #112 
Changed `subsription_filter_policy` to `subscription_filter_policy` everywhere it's used


## Motivation and Context
It makes the parameter name consistent with aws terms
[https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/112](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/112)

