### PR TITLE
feat: Allow Lambda function to be VPC bound

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,9 @@ module "lambda" {
     }
   }
 
+  store_on_s3 = var.lambda_function_store_on_s3
+  s3_bucket   = var.lambda_function_s3_bucket
+
   vpc_subnet_ids         = var.lambda_function_vpc_subnet_ids
   vpc_security_group_ids = var.lambda_function_vpc_security_group_ids
 

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,9 @@ module "lambda" {
     }
   }
 
+  vpc_subnet_ids         = var.lambda_function_vpc_subnet_ids
+  vpc_security_group_ids = var.lambda_function_vpc_security_group_ids
+
   tags = merge(var.tags, var.lambda_function_tags)
 
   depends_on = [aws_cloudwatch_log_group.lambda]

--- a/main.tf
+++ b/main.tf
@@ -30,13 +30,26 @@ locals {
     actions   = ["kms:Decrypt"]
     resources = [var.kms_key_arn]
   }
+
+  lambda_policy_document_vpc = {
+    sid    = "AllowEC2ManageNetworkInterfaces"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:UnassignPrivateIpAddresses"
+    ]
+    resources = ["*"]
+  }
 }
 
 data "aws_iam_policy_document" "lambda" {
   count = var.create ? 1 : 0
 
   dynamic "statement" {
-    for_each = concat([local.lambda_policy_document], var.kms_key_arn != "" ? [local.lambda_policy_document_kms] : [])
+    for_each = concat([local.lambda_policy_document], var.kms_key_arn != "" ? [local.lambda_policy_document_kms] : [], var.lambda_function_vpc_subnet_ids != null ? [local.lambda_policy_document_vpc] : [])
     content {
       sid       = statement.value.sid
       effect    = statement.value.effect

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,18 @@ variable "lambda_function_tags" {
   default     = {}
 }
 
+variable "lambda_function_vpc_subnet_ids" {
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "lambda_function_vpc_security_group_ids" {
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
+}
+
 variable "sns_topic_tags" {
   description = "Additional tags for the SNS topic"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,18 @@ variable "lambda_function_vpc_security_group_ids" {
   default     = null
 }
 
+variable "lambda_function_store_on_s3" {
+  description = "Whether to store produced artifacts on S3 or locally."
+  type        = bool
+  default     = false
+}
+
+variable "lambda_function_s3_bucket" {
+  description = "S3 bucket to store artifacts"
+  type        = string
+  default     = null
+}
+
 variable "sns_topic_tags" {
   description = "Additional tags for the SNS topic"
   type        = map(string)


### PR DESCRIPTION
## Description
Add VPC configuration variables

## Motivation and Context
Depending on the situation, an Organization policy might require that lambda functions are VPC bound. This PR allows to pass VPC configuration down to the underlying lambda module.