### PR TITLE
feat: Allow custom attachement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ terraform.rc
 # Lambda directories
 builds/
 __pycache__/
+functions/pytest.ini

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -83,6 +83,8 @@ def notify_slack(subject, message, region):
     notification = cloudwatch_notification(message, region)
     payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
     payload['attachments'].append(notification)
+  elif "attachments" in message or "text" in message:
+    payload = {**payload, **message}
   else:
     payload['text'] = "AWS notification"
     payload['attachments'].append(default_notification(subject, message))

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -96,6 +96,44 @@ events = (
             "AWSAccountId": "000000000000",
             "NewStateValue": "ALARM",
         }
+    ),
+    (
+        {
+            "attachments": [
+                {
+                    "mrkdwn_in": ["text"],
+                    "color": "#36a64f",
+                    "pretext": "Optional pre-text that appears above the attachment block",
+                    "author_name": "author_name",
+                    "author_link": "http://flickr.com/bobby/",
+                    "author_icon": "https://placeimg.com/16/16/people",
+                    "title": "title",
+                    "title_link": "https://api.slack.com/",
+                    "text": "Optional `text` that appears within the attachment",
+                    "fields": [
+                        {
+                            "title": "A field's title",
+                            "value": "This field's value",
+                            "short": False
+                        },
+                        {
+                            "title": "A short field's title",
+                            "value": "A short field's value",
+                            "short": True
+                        },
+                        {
+                            "title": "A second short field's title",
+                            "value": "A second short field's value",
+                            "short": True
+                        }
+                    ],
+                    "thumb_url": "http://placekitten.com/g/200/200",
+                    "footer": "footer",
+                    "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+                    "ts": 123456789
+                }
+            ]
+        }
     )
 )
 

--- a/functions/pytest.ini
+++ b/functions/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-addopts = --disable-pytest-warnings
-env =
-  SLACK_CHANNEL=general
-  SLACK_EMOJI=:aws:
-  SLACK_USERNAME=anton
-  SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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


### PR DESCRIPTION
## Description
- Supersedes the following stale PR: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/pull/47
Takes the same idea and code and adds a test case for it as requested in the original PR.
- If `attachments` or `text` is found within the event it is assumed that the event follows the slack [message specification](https://api.slack.com/reference/messaging/attachments#fields) and is merged as is with the payload sent to slack.
- Additionally removes and ignores the non default `pytest.ini`.

## Motivation and Context
The default message is not customizable and can be hard to read if there are a lot of fields included.
Knowing the slack API requirements a user should be able to customize the message displayed in slack according to their needs. 

## Breaking Changes
None identified.

## How Has This Been Tested?
Added the [slack message with attachment example](https://api.slack.com/reference/messaging/attachments#example) to the event list in the lambda tests and ran it against a custom slack instance.
All other events still render the same and the event with attachments renders accordingly to the example on the slack example page.