### PR TITLE
feat: Improve slack message formatting for generic messages

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -42,10 +42,18 @@ def cloudwatch_notification(message, region):
 
 
 def default_notification(subject, message):
-  return {
+  attachments = {
     "fallback": "A new message",
-    "fields": [{"title": subject if subject else "Message", "value": json.dumps(message) if type(message) is dict else message, "short": False}]
+    "title": subject if subject else "Message",
+    "fields": []
   }
+  if type(message) is dict:
+    for k, v in message.items():
+      attachments['fields'].append({"title": k, "value": v, "short": False})
+  else:
+    attachments['fields'].append({"value": message, "short": False})
+
+  return attachments
 
 
 # Send a message to a slack channel

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -31,28 +31,52 @@ events = (
         }
     ),
     (
-      {
-        "Records": [
-          {
-            "EventSource": "aws:sns",
-            "EventVersion": "1.0",
-            "EventSubscriptionArn": "arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
-            "Sns": {
-              "Type": "Notification",
-              "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
-              "TopicArn": "arn:aws:sns:eu-west-2:735598076380:service-updates",
-              "Subject": "All Fine",
-              "Message": "This\nis\na typical multi-line\nmessage from SNS!\n\nHave a ~good~ amazing day! :)",
-              "Timestamp": "2019-02-12T15:45:24.091Z",
-              "SignatureVersion": "1",
-              "Signature": "WMYdVRN7ECNXMWZ0faRDD4fSfALW5MISB6O//LMd/LeSQYNQ/1eKYEE0PM1SHcH+73T/f/eVHbID/F203VZaGECQTD4LVA4B0DGAEY39LVbWdPTCHIDC6QCBV5ScGFZcROBXMe3UBWWMQAVTSWTE0eP526BFUTecaDFM4b9HMT4NEHWa4A2TA7d888JaVKKdSVNTd4bGS6Q2XFG1MOb652BRAHdARO7A6//2/47JZ5COM6LR0/V7TcOYCBZ20CRF6L5XLU46YYL3I1PNGKbEC1PIeVDVJVPcA17NfUbFXWYBX8LHfM4O7ZbGAPaGffDYLFWM6TX1Y6fQ01OSMc21OdUGV6HQR01e%==",
-              "SigningCertUrl": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-7dd85a2b76adaa8dd603b7a0c9150589.pem",
-              "UnsubscribeUrl": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
-              "MessageAttributes": {}
-            }
-          }
-        ]
-      }
+        {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "EventVersion": "1.0",
+                    "EventSubscriptionArn": "arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+                    "Sns": {
+                        "Type": "Notification",
+                        "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+                        "TopicArn": "arn:aws:sns:eu-west-2:735598076380:service-updates",
+                        "Subject": "All Fine",
+                        "Message": "This\nis\na typical multi-line\nmessage from SNS!\n\nHave a ~good~ amazing day! :)",
+                        "Timestamp": "2019-02-12T15:45:24.091Z",
+                        "SignatureVersion": "1",
+                        "Signature": "WMYdVRN7ECNXMWZ0faRDD4fSfALW5MISB6O//LMd/LeSQYNQ/1eKYEE0PM1SHcH+73T/f/eVHbID/F203VZaGECQTD4LVA4B0DGAEY39LVbWdPTCHIDC6QCBV5ScGFZcROBXMe3UBWWMQAVTSWTE0eP526BFUTecaDFM4b9HMT4NEHWa4A2TA7d888JaVKKdSVNTd4bGS6Q2XFG1MOb652BRAHdARO7A6//2/47JZ5COM6LR0/V7TcOYCBZ20CRF6L5XLU46YYL3I1PNGKbEC1PIeVDVJVPcA17NfUbFXWYBX8LHfM4O7ZbGAPaGffDYLFWM6TX1Y6fQ01OSMc21OdUGV6HQR01e%==",
+                        "SigningCertUrl": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-7dd85a2b76adaa8dd603b7a0c9150589.pem",
+                        "UnsubscribeUrl": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+                        "MessageAttributes": {}
+                    }
+                }
+            ]
+        }
+    ),
+    (
+        {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "EventVersion": "1.0",
+                    "EventSubscriptionArn": "arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+                    "Sns": {
+                        "Type": "Notification",
+                        "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+                        "TopicArn": "arn:aws:sns:eu-west-2:735598076380:service-updates",
+                        "Subject": "DMS Notification Message",
+                        "Message": "{\"Event Source\": \"replication-task\", \"Event Time\": \"2019-02-12 15:45:24.091\", \"Identifier Link\": \"https://console.aws.amazon.com/dms/home?region=eu-west-2#tasks:ids=hello-world\\nSourceId: hello-world \", \"Event ID\": \"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html#DMS-EVENT-0079 \", \"Event Message\": \"Replication task has stopped.\"}",
+                        "Timestamp": "2019-02-12T15:45:24.091Z",
+                        "SignatureVersion": "1",
+                        "Signature": "WMYdVRN7ECNXMWZ0faRDD4fSfALW5MISB6O//LMd/LeSQYNQ/1eKYEE0PM1SHcH+73T/f/eVHbID/F203VZaGECQTD4LVA4B0DGAEY39LVbWdPTCHIDC6QCBV5ScGFZcROBXMe3UBWWMQAVTSWTE0eP526BFUTecaDFM4b9HMT4NEHWa4A2TA7d888JaVKKdSVNTd4bGS6Q2XFG1MOb652BRAHdARO7A6//2/47JZ5COM6LR0/V7TcOYCBZ20CRF6L5XLU46YYL3I1PNGKbEC1PIeVDVJVPcA17NfUbFXWYBX8LHfM4O7ZbGAPaGffDYLFWM6TX1Y6fQ01OSMc21OdUGV6HQR01e%==",
+                        "SigningCertUrl": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-7dd85a2b76adaa8dd603b7a0c9150589.pem",
+                        "UnsubscribeUrl": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:735598076380:service-updates:d29b4e2c-6840-9c4e-ceac-17128efcc337",
+                        "MessageAttributes": {}
+                    }
+                }
+            ]
+        }
     ),
     (
         {
@@ -67,11 +91,11 @@ events = (
         }
     ),
     (
-      {
-        "AlarmType": "Unsupported alarm type",
-        "AWSAccountId": "000000000000",
-        "NewStateValue": "ALARM",
-      }
+        {
+            "AlarmType": "Unsupported alarm type",
+            "AWSAccountId": "000000000000",
+            "NewStateValue": "ALARM",
+        }
     )
 )
 


### PR DESCRIPTION
## Description
Improves readability of generic messages sent by AWS services.

Before this PR:
![alert0](https://user-images.githubusercontent.com/1767795/107456242-2d576980-6b93-11eb-8807-830a9eaaa860.png)
With this PR:
![alert](https://user-images.githubusercontent.com/1767795/107456058-e79aa100-6b92-11eb-81cc-a2c1fb2fb4e9.png)

## Motivation and Context
Currently messages other than the ones from Cloudwatch are sent as slack messages in verbatim as json strings. I thought by formatting the messages it would enhance its readability. For instance, this happens to messages received from AWS DMS events.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
Ran existing test according to test setup instructions. Existing tests fixtures already provide coverage and this change only affects the formatting of the default notification.
