### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,33 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
 
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Lambda directories
 builds/
+__pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ To run the tests:
 |------|---------|
 | aws | >= 2.35 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda | terraform-aws-modules/lambda/aws | 1.28.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/cloudwatch_log_group) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/data-sources/iam_policy_document) |
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/data-sources/sns_topic) |
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic) |
+| [aws_sns_topic_subscription](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic_subscription) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -140,7 +156,6 @@ To run the tests:
 | notify\_slack\_lambda\_function\_name | The name of the Lambda function |
 | notify\_slack\_lambda\_function\_version | Latest published version of your Lambda function |
 | this\_slack\_topic\_arn | The ARN of the SNS topic from which messages will be sent to Slack |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ To run the tests:
 |------|
 | [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/cloudwatch_log_group) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/data-sources/iam_policy_document) |
+| [aws_sns_topic_subscription](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic_subscription) |
 | [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/data-sources/sns_topic) |
 | [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic) |
-| [aws_sns_topic_subscription](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic_subscription) |
 
 ## Inputs
 

--- a/examples/cloudwatch-alerts-to-slack/README.md
+++ b/examples/cloudwatch-alerts-to-slack/README.md
@@ -71,6 +71,22 @@ Note that this example may create resources which can cost money. Run `terraform
 | aws | >= 2.35 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| notify_slack | ../../ |  |
+| vpc | terraform-aws-modules/vpc/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/cloudwatch_metric_alarm) |
+| [aws_kms_ciphertext](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/kms_ciphertext) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/kms_key) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -87,5 +103,4 @@ No input.
 | notify\_slack\_lambda\_function\_name | The name of the Lambda function |
 | notify\_slack\_lambda\_function\_version | Latest published version of your Lambda function |
 | this\_sns\_topic\_arn | The ARN of the SNS topic from which messages will be sent to Slack |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/notify-slack-simple/README.md
+++ b/examples/notify-slack-simple/README.md
@@ -32,6 +32,18 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | aws | >= 2.35 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| notify_slack | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/2.35/docs/resources/sns_topic) |
+
 ## Inputs
 
 No input.
@@ -49,5 +61,4 @@ No input.
 | notify\_slack\_lambda\_function\_name | The name of the Lambda function |
 | notify\_slack\_lambda\_function\_version | Latest published version of your Lambda function |
 | this\_sns\_topic\_arn | The ARN of the SNS topic from which messages will be sent to Slack |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
