### PR TITLE
fix: Fix regression with aws_cloudwatch_log_group resource after upgr…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     sid       = "AllowWriteToCloudwatchLogs"
     effect    = "Allow"
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = [element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)]
+    resources = [replace("${element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)}:*", ":*:*", ":*")]
   }
 
   lambda_policy_document_kms = {


### PR DESCRIPTION
…ade of AWS provider 3.0 (#106)

## Description
Just cherry picked your commit for the `4.X` version.

## Motivation and Context
Deals with the log group missing wildcard regression for folk who want to upgrade to `provider > 3` but are still in TF12

## Breaking Changes
No

## How Has This Been Tested?
Ran `plan` on my organisation repo and the log-group policy resource correctly ends in `:*` as it was before.
