### PR TITLE
fix: use the current aws partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ To run the tests:
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
 | [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 | [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) |
 | [aws_sns_topic_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) |

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_sns_topic" "this" {
@@ -15,7 +16,7 @@ locals {
   sns_topic_arn = element(
     concat(
       aws_sns_topic.this.*.arn,
-      ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}"],
+      ["arn:${data.aws_partition.current.id}:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}"],
       [""]
     ),
     0,


### PR DESCRIPTION
## Description

This PR re-enables deployment of this module to AWS partitions outside of `aws`. This fixes an issue introduced as a byproduct of https://github.com/terraform-aws-modules/terraform-aws-notify-slack/commit/2c4f15bf48cd96dd55a27faf4e0f5376b2c30268, where previously the partition ARN was dynamically identified through the use of the https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic resource.

## Motivation and Context

Instead of hardcoding to the `aws` partition, this PR re-enables dynamic identification of the current partition through the use of the https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition resource.

Without this PR, I see this error when applying changes that use v4.12.0 of this module:

```text
Error: error creating SNS topic subscription: InvalidParameter: Invalid parameter: TopicArn Reason: A us-gov-west-1 ARN must begin with arn:aws-us-gov, not arn:aws:sns:
us-gov-west-1:xxxxxxxxxxxx:app-gov-alert
        status code: 400, request id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee

  on .terraform/modules/this_module/main.tf line 63, in resource "aws_sns_topic_subscription" "sns_notify_slack":
  63: resource "aws_sns_topic_subscription" "sns_notify_slack" {
```

This error refers to this resource: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/blob/07c936b96155e48e358ac2e70ec1241b455716fa/main.tf#L63-L70

That uses the `local.sns_topic_arn` value defined here with the partition hardcoded to `aws` on line 18:
https://github.com/terraform-aws-modules/terraform-aws-notify-slack/blob/07c936b96155e48e358ac2e70ec1241b455716fa/main.tf#L15-L22

I do not see any open issues that describe this bug.

## Breaking Changes

This does not break backwards compatibility with the current major version.

## How Has This Been Tested?

I tested this by running a `terraform plan` and `terraform apply` in an AWS GovCloud account, which uses the `aws-us-gov` partition. Without this PR, the latest version of this module fails to apply.