### PR TITLE
feat: Added support for GuardDuty Findings format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
 - Support different types of SNS messages:
   - AWS CloudWatch Alarms
   - AWS CloudWatch LogMetrics Alarms
+  - AWS GuardDuty Findings
 - Local pytest driven testing of the lambda to a Slack sandbox channel
 
 ## Feature Roadmap

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -41,6 +41,39 @@ def cloudwatch_notification(message, region):
   }
 
 
+def guardduty_finding(message, region):
+  states = {'Low': '#777777', 'Medium': 'warning', 'High': 'danger'}
+  if region.startswith("us-gov-"):
+    guardduty_url = "https://console.amazonaws-us-gov.com/guardduty/home?region="
+  else:
+    guardduty_url = "https://console.aws.amazon.com/guardduty/home?region="
+
+  if message['detail']['severity'] < 4.0:
+    severity = 'Low'
+  elif message['detail']['severity'] < 7.0:
+    severity = 'Medium'
+  else:
+    severity = 'High'
+
+  return {
+    "color": states[severity],
+    "fallback": "GuardDuty Finding: {}".format(message['detail']['title']),
+    "fields": [
+      {"title": "Description", "value": message['detail']['description'], "short": False },
+      {"title": "Finding type", "value": message['detail']['type'], "short": False},
+      {"title": "First Seen", "value": message['detail']['service']['eventFirstSeen'], "short": True},
+      {"title": "Last Seen", "value": message['detail']['service']['eventLastSeen'], "short": True},
+      {"title": "Severity", "value": severity, "short": True},
+      {"title": "Count", "value": message['detail']['service']['count'], "short": True},
+      {
+        "title": "Link to Finding",
+        "value": guardduty_url + region + "#/findings?search=id%3D" + message['detail']['id'],
+        "short": False
+      }
+    ]
+  }
+
+
 def default_notification(subject, message):
   attachments = {
     "fallback": "A new message",
@@ -90,6 +123,10 @@ def notify_slack(subject, message, region):
   if "AlarmName" in message:
     notification = cloudwatch_notification(message, region)
     payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
+    payload['attachments'].append(notification)
+  elif "detail-type" in message and message["detail-type"] == "GuardDuty Finding":
+    notification = guardduty_finding(message, message["region"])
+    payload['text'] = "Amazon GuardDuty Finding - " + message["detail"]["title"]
     payload['attachments'].append(notification)
   elif "attachments" in message or "text" in message:
     payload = {**payload, **message}

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -158,7 +158,25 @@ events = (
           }
         ]
       }
-    )
+    ),
+    (
+        {
+            "detail-type": "GuardDuty Finding",
+            "region": "us-east-1",
+            "detail": {
+                "id": "sample-id-2",
+                "title": "SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                "severity": 9,
+                "description": "EC2 instance has an unprotected port which is being probed by a known malicious host.",
+                "type": "Recon:EC2/PortProbeUnprotectedPort",
+                "service": {
+                  "eventFirstSeen":"2020-01-02T01:02:03Z",
+                  "eventLastSeen":"2020-01-03T01:02:03Z",
+                  "count": 1234
+                }
+            },
+        }
+    ),
 )
 
 


### PR DESCRIPTION
## Description
This adds formatting for Guardduty Findings.  This is based on #127 but resolving the feedback and adding tests.  Thank you to @iogi for their original contribution I just want to see this to the finish line.

## Motivation and Context
The Guard Duty findings were not properly reported in this module and were hidden away in the details of this SNS event structure.

## Breaking Changes
NO

## How Has This Been Tested?
* I have tested this in a test and an few customer environments
* I have added a test into the pytest to validate the formatting is working properly

## Screenshot
<img width="621" alt="Screen Shot 2021-07-12 at 11 29 11 PM" src="https://user-images.githubusercontent.com/470163/125280319-0501b000-e369-11eb-9e56-c77805194cdb.png">

Closes #127 