### PR TITLE
feat: Adding a custom SNS topic policy, to allow stuff like guardduty access

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To run the tests:
 | <a name="input_sns_topic_kms_key_id"></a> [sns\_topic\_kms\_key\_id](#input\_sns\_topic\_kms\_key\_id) | ARN of the KMS key used for enabling SSE on the topic | `string` | `""` | no |
 | <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | The name of the SNS topic to create | `string` | n/a | yes |
 | <a name="input_sns_topic_tags"></a> [sns\_topic\_tags](#input\_sns\_topic\_tags) | Additional tags for the SNS topic | `map(string)` | `{}` | no |
+| <a name="input_sns_topic_access_policy"></a> [sns\_topic\_access\_policy](#input\_sns\_topic\_access\_policy) | The SNS Topic access policy, customize this if you wish to allow things like Guardduty access to this SNS topic | `string` | `null` | no |
 | <a name="input_subscription_filter_policy"></a> [subscription\_filter\_policy](#input\_subscription\_filter\_policy) | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,8 @@ resource "aws_sns_topic" "this" {
   kms_master_key_id = var.sns_topic_kms_key_id
 
   tags = merge(var.tags, var.sns_topic_tags)
+
+  policy = var.sns_topic_access_policy
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "sns_topic_name" {
 }
 
 variable "sns_topic_access_policy" {
-  description = "A custom SNS access policy, use this to customize and grant more services and cross-account access to your SNS topic"
+  description = "The SNS access policy, use this to grant cross-account access, or more services (eg: budgets/guardduty) to your SNS topic"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "sns_topic_name" {
   type        = string
 }
 
+variable "sns_topic_access_policy" {
+  description = "A custom SNS access policy, use this to customize and grant more services and cross-account access to your SNS topic"
+  type        = string
+  default     = null
+}
+
 variable "sns_topic_kms_key_id" {
   description = "ARN of the KMS key used for enabling SSE on the topic"
   type        = string


### PR DESCRIPTION
## Description
This allows you to customize the SNS Access Policy that is created.  The "default" one that is created locks the SNS topic to only be able to be used by any services coming "from" this AWS account it was deployed to, so it won't support cross-account access, nor will it support services with SNS messages which originate from other AWS accounts (Eg: Guardduty and Billing Alerts)

## Motivation and Context
So people don't have to manually edit things "outside" of Terraform which are out-of-sync of Terraform forever.  This policy will need to be able to be customized in most larger/enterprise environments.

## Breaking Changes
None

## How Has This Been Tested?
* Tested with no variable provided, default policy is created (same as before)
* Tested with a custom policy provided, works and grants access to whatever other services you add (in my case, billing and guardduty)

Relates to #143 