### PR TITLE
feat: Add Content-Type and Content-Length on request

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import uuid
 from urllib.error import HTTPError
 import os, boto3, json, base64
 import urllib.request, urllib.parse

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+
+import uuid
 from urllib.error import HTTPError
 import os, boto3, json, base64
 import urllib.request, urllib.parse
@@ -97,8 +99,10 @@ def notify_slack(subject, message, region):
     payload['text'] = "AWS notification"
     payload['attachments'].append(default_notification(subject, message))
 
-  data = urllib.parse.urlencode({"payload": json.dumps(payload)}).encode("utf-8")
+  data = json.dumps(payload).encode('utf-8')
   req = urllib.request.Request(slack_url)
+  req.add_header('Content-Type', 'application/json; charset=utf-8')
+  req.add_header('Content-Length', len(data))
 
   try:
     result = urllib.request.urlopen(req, data)

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-
 from urllib.error import HTTPError
 import os, boto3, json, base64
 import urllib.request, urllib.parse


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Slack's API documentation states that for JSON-encoded bodies client must explicitly set the **Content-type** HTTP header to `application/json`. This function does not explicitly set it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have internally created a wrapper of slack's api. Basically one single app is used by many internal purposes. We had followed strictly the API definition of Slack, including the enforcement of the **Content-type**. Turns out that this function didn't work seamlessly with this broker, and the reason was the  **Content-type**.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This change does not affect neither the current nor latest versions of this module

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made use of the same **notify_slack_test.py** against a personal channel of Slack. All kind of message went through well
