### PR TITLE
feat: Add ephemeral_storage_size variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.1.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.2.0 |
 
 ## Resources
 
@@ -106,6 +106,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Additional tags for the IAM role | `map(string)` | `{}` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for decrypting slack webhook url | `string` | `""` | no |
 | <a name="input_lambda_description"></a> [lambda\_description](#input\_lambda\_description) | The description of the Lambda function | `string` | `null` | no |
+| <a name="input_lambda_function_ephemeral_storage_size"></a> [lambda\_function\_ephemeral\_storage\_size](#input\_lambda\_function\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
 | <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | The name of the Lambda function to create | `string` | `"notify_slack"` | no |
 | <a name="input_lambda_function_s3_bucket"></a> [lambda\_function\_s3\_bucket](#input\_lambda\_function\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
 | <a name="input_lambda_function_store_on_s3"></a> [lambda\_function\_store\_on\_s3](#input\_lambda\_function\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   create = var.create
 
@@ -84,6 +84,7 @@ module "lambda" {
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions
+  ephemeral_storage_size         = var.lambda_function_ephemeral_storage_size
 
   # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack:
   # InvalidParameterValueException: We currently do not support adding policies for $LATEST."

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,12 @@ variable "lambda_function_s3_bucket" {
   default     = null
 }
 
+variable "lambda_function_ephemeral_storage_size" {
+  description = "Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB)."
+  type        = number
+  default     = 512
+}
+
 variable "sns_topic_tags" {
   description = "Additional tags for the SNS topic"
   type        = map(string)


### PR DESCRIPTION
## Description

When using this module in GovCloud, we get this error (this is sanitized):
```
│ Error: error modifying Lambda Function (lambda-name) configuration : InvalidParameterValueException: Ephemeral storage configuration ('ephemeralStorage') is currently not supported. Please remove the ephemeral storage parameter from your request and try again.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "..."
│   },
│   Message_: "Ephemeral storage configuration ('ephemeralStorage') is currently not supported. Please remove the ephemeral storage parameter from your request and try again.",
│   Type: "User"
│ }
```

This was fixed in 3.1.1 of terraform-aws-lambda: https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/304#issuecomment-1098448429

This PR does two things:
1. Upgrades the version of terraform-aws-lambda to the latest: 3.2.0
2. Allows for the configuration of ephemeral_storage_size by adding a new variable.

When adding the new variable, I followed the naming scheme I observed here (e.g.: `lambda_function_variable_name_from_submodule`): https://github.com/terraform-aws-modules/terraform-aws-notify-slack/blob/1d7bfe9a6b277aba2732e51ff5e241214395a491/variables.tf#L135-L163

I copied the description, type, and default from here: https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/19b9f11fc8ed04a34c02db553d3f463cab6b740a/variables.tf#L112-L116

## Motivation and Context

Without this change, using this module in GovCloud results in this error:

```
Ephemeral storage configuration ('ephemeralStorage') is currently not supported. Please remove the ephemeral storage parameter from your request and try again.
```

This is the same issue described here: https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/304

## Breaking Changes

This does not break backward compatibility. The default in this module (512) is the same as the default used by the terraform-aws-lambda module (512).

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I tested this by running `terraform apply` with it in GovCloud. The error no longer occurs when I set `lambda_function_ephemeral_storage_size` to `null`.