### PR TITLE
feat: Add support for pre-built lambda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
 - Create new SNS topic or use existing one
 - Support plaintext and encrypted version of Slack webhook URL
 - Most of Slack message options are customizable
-- Custom Lambda function
+- Custom Lambda function, or pre-built package
 - Various event types are supported, even generic messages:
   - AWS CloudWatch Alarms
   - AWS CloudWatch LogMetrics Alarms
@@ -116,6 +116,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_lambda_function_vpc_subnet_ids"></a> [lambda\_function\_vpc\_subnet\_ids](#input\_lambda\_function\_vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |
 | <a name="input_lambda_role"></a> [lambda\_role](#input\_lambda\_role) | IAM role attached to the Lambda Function.  If this is set then a role will not be created for you. | `string` | `""` | no |
 | <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | The source path of the custom Lambda function | `string` | `null` | no |
+| <a name="input_lamdba_package_path"></a> [lamdba\_package\_path](#input\_lamdba\_package\_path) | The source path of the pre-built Lambda package. If this is set then lambda\_source\_path will be ignored. | `string` | `null` | no |
 | <a name="input_log_events"></a> [log\_events](#input\_log\_events) | Boolean flag to enabled/disable logging of incoming events | `bool` | `false` | no |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |

--- a/main.tf
+++ b/main.tf
@@ -79,8 +79,12 @@ module "lambda" {
   function_name = var.lambda_function_name
   description   = var.lambda_description
 
-  handler                        = "${local.lambda_handler}.lambda_handler"
-  source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
+  handler = "${local.lambda_handler}.lambda_handler"
+
+  create_package         = var.lamdba_package_path != null ? false : true
+  local_existing_package = var.lamdba_package_path != null ? var.lamdba_package_path : null
+  source_path            = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
+
   recreate_missing_package       = var.recreate_missing_package
   runtime                        = "python3.8"
   timeout                        = 30

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "lambda_source_path" {
   default     = null
 }
 
+variable "lamdba_package_path" {
+  description = "The source path of the pre-built Lambda package. If this is set then lambda_source_path will be ignored."
+  type        = string
+  default     = null
+}
+
 variable "sns_topic_name" {
   description = "The name of the SNS topic to create"
   type        = string


### PR DESCRIPTION
## Description
This change adds support for supplying a pre-built lambda package to the module by adding the `local_existing_package` variable. If this variable is populated with a path to the package, the package is used and `source_path` is ignored.

## Motivation and Context
Fixes #174 

## Breaking Changes
No breaking changes detected

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I ran terraform in the [notify-slack-simple](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/tree/master/examples/notify-slack-simple) project. It was built correctly without any errors. I then supplied a `local_existing_package` variable and ran terraform again, and the resource updated correctly without errors. 
