### PR TITLE
feat: Add lambda dead-letter queue variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Additional tags for the IAM role | `map(string)` | `{}` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for decrypting slack webhook url | `string` | `""` | no |
+| <a name="input_lambda_attach_dead_letter_policy"></a> [lambda\_attach\_dead\_letter\_policy](#input\_lambda\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_lambda_dead_letter_target_arn"></a> [lambda\_dead\_letter\_target\_arn](#input\_lambda\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
 | <a name="input_lambda_description"></a> [lambda\_description](#input\_lambda\_description) | The description of the Lambda function | `string` | `null` | no |
 | <a name="input_lambda_function_ephemeral_storage_size"></a> [lambda\_function\_ephemeral\_storage\_size](#input\_lambda\_function\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
 | <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | The name of the Lambda function to create | `string` | `"notify_slack"` | no |

--- a/examples/notify-slack-dlq/README.md
+++ b/examples/notify-slack-dlq/README.md
@@ -1,0 +1,70 @@
+Basic Slack notification with dead letter queue
+===============================================
+
+Configuration in this directory creates an SNS topic that sends messages to a Slack channel. An SQS queue is also created to use as the target arn for the lambda function's dead letter queue.
+
+Note, this example does not use KMS key.
+
+Usage
+=====
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_custom_lambda"></a> [custom\_lambda](#module\_custom\_lambda) | ../../ | n/a |
+| <a name="module_notify_slack_with_dlq"></a> [notify\_slack\_with\_dlq](#module\_notify\_slack\_with\_dlq) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_sns_topic.custom_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sqs_queue.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [local_file.integration_testing](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The Amazon Resource Name (ARN) specifying the log group |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | The ARN of the IAM role used by Lambda function |
+| <a name="output_lambda_iam_role_name"></a> [lambda\_iam\_role\_name](#output\_lambda\_iam\_role\_name) | The name of the IAM role used by Lambda function |
+| <a name="output_notify_slack_lambda_function_arn"></a> [notify\_slack\_lambda\_function\_arn](#output\_notify\_slack\_lambda\_function\_arn) | The ARN of the Lambda function |
+| <a name="output_notify_slack_lambda_function_invoke_arn"></a> [notify\_slack\_lambda\_function\_invoke\_arn](#output\_notify\_slack\_lambda\_function\_invoke\_arn) | The ARN to be used for invoking Lambda function from API Gateway |
+| <a name="output_notify_slack_lambda_function_last_modified"></a> [notify\_slack\_lambda\_function\_last\_modified](#output\_notify\_slack\_lambda\_function\_last\_modified) | The date Lambda function was last modified |
+| <a name="output_notify_slack_lambda_function_name"></a> [notify\_slack\_lambda\_function\_name](#output\_notify\_slack\_lambda\_function\_name) | The name of the Lambda function |
+| <a name="output_notify_slack_lambda_function_version"></a> [notify\_slack\_lambda\_function\_version](#output\_notify\_slack\_lambda\_function\_version) | Latest published version of your Lambda function |
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The ARN of the SNS topic from which messages will be sent to Slack |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/notify-slack-dlq/custom-lambda.tf
+++ b/examples/notify-slack-dlq/custom-lambda.tf
@@ -1,0 +1,36 @@
+locals {
+  custom = {
+    name = "ex-${replace(basename(path.cwd), "_", "-")}-custom"
+    tags = merge({ "Type" = "custom" }, local.tags)
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+resource "aws_sns_topic" "custom_lambda" {
+  name = local.custom.name
+  tags = local.custom.tags
+}
+
+################################################################################
+# Slack Notify Module
+################################################################################
+
+module "custom_lambda" {
+  source = "../../"
+
+  lambda_function_name = "custom_lambda"
+  lambda_source_path   = "../../functions/mylambda.py"
+
+  iam_role_name_prefix = "custom"
+
+  sns_topic_name = aws_sns_topic.custom_lambda.name
+
+  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
+  slack_channel     = "aws-notification"
+  slack_username    = "reporter"
+
+  tags = local.custom.tags
+}

--- a/examples/notify-slack-dlq/main.tf
+++ b/examples/notify-slack-dlq/main.tf
@@ -1,0 +1,59 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
+  region = "eu-west-1"
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+resource "aws_sns_topic" "example" {
+  name = local.name
+  tags = local.tags
+}
+
+resource "aws_sqs_queue" "example" {
+  name = local.name
+  tags = local.tags
+}
+
+################################################################################
+# Slack Notify Module
+################################################################################
+
+module "notify_slack_with_dlq" {
+  source = "../../"
+
+  sns_topic_name                   = aws_sns_topic.example.name
+  create_sns_topic                 = false
+  lambda_dead_letter_target_arn    = aws_sqs_queue.example.arn
+  lambda_attach_dead_letter_policy = true
+
+  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
+  slack_channel     = "aws-notification"
+  slack_username    = "reporter"
+
+  tags = local.tags
+}
+
+################################################################################
+# Integration Testing Support
+# This populates a file that is gitignored to aid in executing the integration tests locally
+################################################################################
+
+resource "local_file" "integration_testing" {
+  filename = "${path.module}/../../functions/.int.env"
+  content  = <<-EOT
+    REGION=${local.region}
+    LAMBDA_FUNCTION_NAME=${module.notify_slack_with_dlq.notify_slack_lambda_function_name}
+    SNS_TOPIC_ARN=${aws_sns_topic.example.arn}
+    EOT
+}

--- a/examples/notify-slack-dlq/outputs.tf
+++ b/examples/notify-slack-dlq/outputs.tf
@@ -1,0 +1,44 @@
+output "sns_topic_arn" {
+  description = "The ARN of the SNS topic from which messages will be sent to Slack"
+  value       = module.notify_slack_with_dlq.slack_topic_arn
+}
+
+output "lambda_iam_role_arn" {
+  description = "The ARN of the IAM role used by Lambda function"
+  value       = module.notify_slack_with_dlq.lambda_iam_role_arn
+}
+
+output "lambda_iam_role_name" {
+  description = "The name of the IAM role used by Lambda function"
+  value       = module.notify_slack_with_dlq.lambda_iam_role_name
+}
+
+output "notify_slack_lambda_function_arn" {
+  description = "The ARN of the Lambda function"
+  value       = module.notify_slack_with_dlq.notify_slack_lambda_function_arn
+}
+
+output "notify_slack_lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.notify_slack_with_dlq.notify_slack_lambda_function_name
+}
+
+output "notify_slack_lambda_function_invoke_arn" {
+  description = "The ARN to be used for invoking Lambda function from API Gateway"
+  value       = module.notify_slack_with_dlq.notify_slack_lambda_function_invoke_arn
+}
+
+output "notify_slack_lambda_function_last_modified" {
+  description = "The date Lambda function was last modified"
+  value       = module.notify_slack_with_dlq.notify_slack_lambda_function_last_modified
+}
+
+output "notify_slack_lambda_function_version" {
+  description = "Latest published version of your Lambda function"
+  value       = module.notify_slack_with_dlq.notify_slack_lambda_function_version
+}
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = module.notify_slack_with_dlq.lambda_cloudwatch_log_group_arn
+}

--- a/examples/notify-slack-dlq/versions.tf
+++ b/examples/notify-slack-dlq/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.8"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,9 @@ module "lambda" {
   use_existing_cloudwatch_log_group = true
   attach_network_policy             = var.lambda_function_vpc_subnet_ids != null
 
+  dead_letter_target_arn    = var.lambda_dead_letter_target_arn
+  attach_dead_letter_policy = var.lambda_attach_dead_letter_policy
+
   allowed_triggers = {
     AllowExecutionFromSNS = {
       principal  = "sns.amazonaws.com"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,18 @@ variable "lambda_source_path" {
   default     = null
 }
 
+variable "lambda_dead_letter_target_arn" {
+  description = "The ARN of an SNS topic or SQS queue to notify when an invocation fails."
+  type        = string
+  default     = null
+}
+
+variable "lambda_attach_dead_letter_policy" {
+  description = "Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function"
+  type        = bool
+  default     = false
+}
+
 variable "sns_topic_name" {
   description = "The name of the SNS topic to create"
   type        = string


### PR DESCRIPTION
## Description
This PR allows the user of the module to configure a dead-letter queue for the lambda function and attach the appropriate permissions to the IAM role.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is attempting to resolve #177 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [✅  ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [✅  ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [✅  ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
