### PR TITLE
feat!: Added variable to filter body of message on SNS level and bumped min Terraform version to 1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.79.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | The name of the SNS topic to create | `string` | n/a | yes |
 | <a name="input_sns_topic_tags"></a> [sns\_topic\_tags](#input\_sns\_topic\_tags) | Additional tags for the SNS topic | `map(string)` | `{}` | no |
 | <a name="input_subscription_filter_policy"></a> [subscription\_filter\_policy](#input\_subscription\_filter\_policy) | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
+| <a name="input_subscription_filter_policy_scope"></a> [subscription\_filter\_policy\_scope](#input\_subscription\_filter\_policy\_scope) | (Optional) A valid filter policy scope MessageAttributes\|MessageBody | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/cloudwatch-alerts-to-slack/README.md
+++ b/examples/cloudwatch-alerts-to-slack/README.md
@@ -60,7 +60,7 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/cloudwatch-alerts-to-slack/versions.tf
+++ b/examples/cloudwatch-alerts-to-slack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/notify-slack-simple/README.md
+++ b/examples/notify-slack-simple/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0 |
 

--- a/examples/notify-slack-simple/versions.tf
+++ b/examples/notify-slack-simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -71,10 +71,11 @@ resource "aws_sns_topic" "this" {
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
   count = var.create ? 1 : 0
 
-  topic_arn     = local.sns_topic_arn
-  protocol      = "lambda"
-  endpoint      = module.lambda.lambda_function_arn
-  filter_policy = var.subscription_filter_policy
+  topic_arn           = local.sns_topic_arn
+  protocol            = "lambda"
+  endpoint            = module.lambda.lambda_function_arn
+  filter_policy       = var.subscription_filter_policy
+  filter_policy_scope = var.subscription_filter_policy_scope
 }
 
 module "lambda" {

--- a/variables.tf
+++ b/variables.tf
@@ -263,3 +263,9 @@ variable "subscription_filter_policy" {
   type        = string
   default     = null
 }
+
+variable "subscription_filter_policy_scope" {
+  description = "(Optional) A valid filter policy scope MessageAttributes|MessageBody"
+  type        = string
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
Add variable for passing filter_policy_scope

## Motivation and Context
I want to filter body of message on SNS level.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
