### PR TITLE
feat: Expose `hash_extra` variable from Lambda module

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_create"></a> [create](#input\_create) | Whether to create all resources | `bool` | `true` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create new SNS topic | `bool` | `true` | no |
 | <a name="input_enable_sns_topic_delivery_status_logs"></a> [enable\_sns\_topic\_delivery\_status\_logs](#input\_enable\_sns\_topic\_delivery\_status\_logs) | Whether to enable SNS topic delivery status logs | `bool` | `false` | no |
+| <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | Path of policies to that should be added to IAM role for Lambda Function | `string` | `null` | no |
 | <a name="input_iam_role_boundary_policy_arn"></a> [iam\_role\_boundary\_policy\_arn](#input\_iam\_role\_boundary\_policy\_arn) | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
 | <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | A unique role name beginning with the specified prefix | `string` | `"lambda"` | no |

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ module "lambda" {
   function_name = var.lambda_function_name
   description   = var.lambda_description
 
+  hash_extra                     = var.hash_extra
   handler                        = "${local.lambda_handler}.lambda_handler"
   source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
   recreate_missing_package       = var.recreate_missing_package

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "create_sns_topic" {
   default     = true
 }
 
+variable "hash_extra" {
+  description = "The string to add into hashing function. Useful when building same source path for different functions."
+  type        = string
+  default     = ""
+}
+
 variable "lambda_role" {
   description = "IAM role attached to the Lambda Function.  If this is set then a role will not be created for you."
   type        = string


### PR DESCRIPTION
## Description
This PR adds a `hash_exta` variable and passes it to the Lambda module. This is useful when this module is called more than once in a workspace. Multiple zip file creations can overlap, causing corruption. 

## Motivation and Context
- Resolves #210

## Breaking Changes
Does not break anything, hash_extra defaults to `""`

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
