### PR TITLE
feat: Add support for System Manager Run Command notification format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
   - AWS CloudWatch Alarms
   - AWS CloudWatch LogMetrics Alarms
   - AWS GuardDuty Findings
-
+  - AWS System Manager Run Command Notifications
 
 ## Usage
 

--- a/functions/events/ssm_run_command_event.json
+++ b/functions/events/ssm_run_command_event.json
@@ -1,9 +1,0 @@
-{
-    "commandId": "6f69316a-e502-5a20-99bc-2408825b6dee",
-    "documentName": "AWS-RunPatchBaseline",
-    "instanceId": "i-99999999999999999",
-    "requestedDateTime": "2023-12-14T10:48:47.127Z",
-    "status": "Success",
-    "detailedStatus": "Success",
-    "eventTime": "2023-12-14T10:52:22.114Z"
-}

--- a/functions/events/ssm_run_command_event.json
+++ b/functions/events/ssm_run_command_event.json
@@ -1,0 +1,9 @@
+{
+    "commandId": "6f69316a-e502-5a20-99bc-2408825b6dee",
+    "documentName": "AWS-RunPatchBaseline",
+    "instanceId": "i-99999999999999999",
+    "requestedDateTime": "2023-12-14T10:48:47.127Z",
+    "status": "Success",
+    "detailedStatus": "Success",
+    "eventTime": "2023-12-14T10:52:22.114Z"
+}

--- a/functions/events/ssm_run_command_event_failed.json
+++ b/functions/events/ssm_run_command_event_failed.json
@@ -1,0 +1,9 @@
+{
+    "commandId": "6f69316a-e502-5a20-99bc-2408825b6dee",
+    "documentName": "AWS-RunPatchBaseline",
+    "instanceId": "i-99999999999999999",
+    "requestedDateTime": "2023-12-14T10:48:47.127Z",
+    "status": "Failed",
+    "detailedStatus": "Failed",
+    "eventTime": "2023-12-14T10:52:22.114Z"
+}

--- a/functions/events/ssm_run_command_event_success.json
+++ b/functions/events/ssm_run_command_event_success.json
@@ -1,0 +1,9 @@
+{
+    "commandId": "6f69316a-e502-5a20-99bc-2408825b6dee",
+    "documentName": "AWS-RunPatchBaseline",
+    "instanceId": "i-99999999999999999",
+    "requestedDateTime": "2023-12-14T10:48:47.127Z",
+    "status": "Success",
+    "detailedStatus": "Success",
+    "eventTime": "2023-12-14T10:52:22.114Z"
+}

--- a/functions/events/ssm_run_command_event_timedout.json
+++ b/functions/events/ssm_run_command_event_timedout.json
@@ -1,0 +1,9 @@
+{
+    "commandId": "6f69316a-e502-5a20-99bc-2408825b6dee",
+    "documentName": "AWS-RunPatchBaseline",
+    "instanceId": "i-99999999999999999",
+    "requestedDateTime": "2023-12-14T10:48:47.127Z",
+    "status": "TimedOut",
+    "detailedStatus": "DeliveryTimedOut",
+    "eventTime": "2023-12-14T10:52:22.114Z"
+}

--- a/functions/messages/ssm_run_command_event.json
+++ b/functions/messages/ssm_run_command_event.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1::ExampleTopic",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "d3cece60-336d-5967-844b-9394d3cb44ba",
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:ExampleTopic",
+                "Subject": "EC2 Run Command Notification us-east-1",
+                "Message": "{\"commandId\":\"6f69316a-e502-5a20-99bc-2408825b6dee\",\"documentName\":\"AWS-RunPatchBaseline\",\"instanceId\":\"i-99999999999999999\",\"requestedDateTime\":\"2023-12-14T10:48:47.127Z\",\"status\":\"Success\",\"detailedStatus\":\"Success\",\"eventTime\":\"2023-12-14T10:52:22.114Z\"}",
+                "Timestamp": "2023-12-14T10:52:22.173Z",
+                "SignatureVersion": "1",
+                "Signature": "EXAMPLE",
+                "SigningCertUrl": "EXAMPLE",
+                "UnsubscribeUrl": "EXAMPLE",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -265,6 +265,70 @@ def format_aws_health(message: Dict[str, Any], region: str) -> Dict[str, Any]:
         ],
     }
 
+class SSMRunCommandStatus(Enum):
+    """Maps System Manager Run Command status to Slack message format color"""
+
+    Success = "good"
+    TimedOut = "danger"
+    Failed = "danger"
+
+def format_ssm_run_command(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format AWS System Manager Run Document event into Slack message format
+
+    :params message: SNS message body containing AWS Health event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+
+    return {
+        "color": SSMRunCommandStatus[message.get('status')].value,
+        "text": f"EC2 Run Command Notification {region}",
+        "fallback": f"EC2 Run Command Notification  {region}",
+        "fields": [
+            {   
+                "title": "Command Id", 
+                "value": f"`{message.get('commandId')}`",
+                "short": True
+            },
+            {
+                "title": "Region",
+                "value": f"`{region}`",
+                "short": True,
+            },
+            {
+                "title": "Document Name",
+                "value": f"`{message.get('documentName')}`",
+                "short": False,
+            },
+            {
+                "title": "Instance Id",
+                "value": f"`{message.get('instanceId')}`",
+                "short": False,
+            },
+            {
+                "title": "Requested Time",
+                "value": f"`{message.get('requestedDateTime')}`",
+                "short": True,
+            },
+            {
+                "title": "Event Time",
+                "value": f"`{message.get('eventTime')}`",
+                "short": True,
+            },
+            {
+                "title": "Status",
+                "value": f"`{message.get('status')}`",
+                "short": False,
+            },
+            {
+                "title": "Detailed Status",
+                "value": f"`{message.get('detailedStatus')}`",
+                "short": False,
+            }
+        ],
+    }
+
 
 def format_default(
     message: Union[str, Dict], subject: Optional[str] = None
@@ -342,6 +406,10 @@ def get_slack_message_payload(
 
     elif isinstance(message, Dict) and message.get("detail-type") == "AWS Health Event":
         notification = format_aws_health(message=message, region=message["region"])
+        attachment = notification
+
+    elif "documentName" in message:
+        notification = format_ssm_run_command(message=message, region=region)
         attachment = notification
 
     elif "attachments" in message or "text" in message:

--- a/functions/snapshots/snap_notify_slack_test.py
+++ b/functions/snapshots/snap_notify_slack_test.py
@@ -4,431 +4,813 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    "test_event_get_slack_message_payload_snapshots event_aws_health_event.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_aws_health_event.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "danger",
-                "fallback": "New AWS Health Event for EC2",
-                "fields": [
-                    {"short": True, "title": "Affected Service", "value": "`EC2`"},
-                    {"short": True, "title": "Affected Region", "value": "`us-west-2`"},
+                'color': 'danger',
+                'fallback': 'New AWS Health Event for EC2',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Code",
-                        "value": "`AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED`",
+                        'short': True,
+                        'title': 'Affected Service',
+                        'value': '`EC2`'
                     },
                     {
-                        "short": False,
-                        "title": "Event Description",
-                        "value": "`A description of the event will be provided here`",
+                        'short': True,
+                        'title': 'Affected Region',
+                        'value': '`us-west-2`'
                     },
                     {
-                        "short": False,
-                        "title": "Affected Resources",
-                        "value": "`i-abcd1111`",
+                        'short': False,
+                        'title': 'Code',
+                        'value': '`AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED`'
                     },
                     {
-                        "short": True,
-                        "title": "Start Time",
-                        "value": "`Sat, 05 Jun 2016 15:10:09 GMT`",
+                        'short': False,
+                        'title': 'Event Description',
+                        'value': '`A description of the event will be provided here`'
                     },
-                    {"short": True, "title": "End Time", "value": "`<unknown>`"},
                     {
-                        "short": False,
-                        "title": "Link to Event",
-                        "value": "https://phd.aws.amazon.com/phd/home?region=us-west-2#/dashboard/open-issues",
+                        'short': False,
+                        'title': 'Affected Resources',
+                        'value': '`i-abcd1111`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Start Time',
+                        'value': '`Sat, 05 Jun 2016 15:10:09 GMT`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'End Time',
+                        'value': '`<unknown>`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Event',
+                        'value': 'https://phd.aws.amazon.com/phd/home?region=us-west-2#/dashboard/open-issues'
+                    }
                 ],
-                "text": "New AWS Health Event for EC2",
+                'text': 'New AWS Health Event for EC2'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_event_get_slack_message_payload_snapshots event_cloudwatch_alarm.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_cloudwatch_alarm.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "danger",
-                "fallback": "Alarm Example triggered",
-                "fields": [
-                    {"short": True, "title": "Alarm Name", "value": "`Example`"},
+                'color': 'danger',
+                'fallback': 'Alarm Example triggered',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Alarm Description",
-                        "value": "`Example alarm description.`",
+                        'short': True,
+                        'title': 'Alarm Name',
+                        'value': '`Example`'
                     },
                     {
-                        "short": False,
-                        "title": "Alarm reason",
-                        "value": "`Threshold Crossed`",
+                        'short': False,
+                        'title': 'Alarm Description',
+                        'value': '`Example alarm description.`'
                     },
-                    {"short": True, "title": "Old State", "value": "`OK`"},
-                    {"short": True, "title": "Current State", "value": "`ALARM`"},
                     {
-                        "short": False,
-                        "title": "Link to Alarm",
-                        "value": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=Example",
+                        'short': False,
+                        'title': 'Alarm reason',
+                        'value': '`Threshold Crossed`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Old State',
+                        'value': '`OK`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Current State',
+                        'value': '`ALARM`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Alarm',
+                        'value': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=Example'
+                    }
                 ],
-                "text": "AWS CloudWatch notification - Example",
+                'text': 'AWS CloudWatch notification - Example'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_high.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_guardduty_finding_high.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "danger",
-                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
-                "fields": [
+                'color': 'danger',
+                'fallback': 'GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Description",
-                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`EC2 instance has an unprotected port which is being probed by a known malicious host.`'
                     },
                     {
-                        "short": False,
-                        "title": "Finding Type",
-                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                        'short': False,
+                        'title': 'Finding Type',
+                        'value': '`Recon:EC2 PortProbeUnprotectedPort`'
                     },
                     {
-                        "short": True,
-                        "title": "First Seen",
-                        "value": "`2020-01-02T01:02:03Z`",
+                        'short': True,
+                        'title': 'First Seen',
+                        'value': '`2020-01-02T01:02:03Z`'
                     },
                     {
-                        "short": True,
-                        "title": "Last Seen",
-                        "value": "`2020-01-03T01:02:03Z`",
+                        'short': True,
+                        'title': 'Last Seen',
+                        'value': '`2020-01-03T01:02:03Z`'
                     },
-                    {"short": True, "title": "Severity", "value": "`High`"},
-                    {"short": True, "title": "Account ID", "value": "`123456789`"},
-                    {"short": True, "title": "Count", "value": "`1234`"},
                     {
-                        "short": False,
-                        "title": "Link to Finding",
-                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`High`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Count',
+                        'value': '`1234`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Finding',
+                        'value': 'https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2'
+                    }
                 ],
-                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                'text': 'AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_low.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_guardduty_finding_low.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "#777777",
-                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
-                "fields": [
+                'color': '#777777',
+                'fallback': 'GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Description",
-                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`EC2 instance has an unprotected port which is being probed by a known malicious host.`'
                     },
                     {
-                        "short": False,
-                        "title": "Finding Type",
-                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                        'short': False,
+                        'title': 'Finding Type',
+                        'value': '`Recon:EC2 PortProbeUnprotectedPort`'
                     },
                     {
-                        "short": True,
-                        "title": "First Seen",
-                        "value": "`2020-01-02T01:02:03Z`",
+                        'short': True,
+                        'title': 'First Seen',
+                        'value': '`2020-01-02T01:02:03Z`'
                     },
                     {
-                        "short": True,
-                        "title": "Last Seen",
-                        "value": "`2020-01-03T01:02:03Z`",
+                        'short': True,
+                        'title': 'Last Seen',
+                        'value': '`2020-01-03T01:02:03Z`'
                     },
-                    {"short": True, "title": "Severity", "value": "`Low`"},
-                    {"short": True, "title": "Account ID", "value": "`123456789`"},
-                    {"short": True, "title": "Count", "value": "`1234`"},
                     {
-                        "short": False,
-                        "title": "Link to Finding",
-                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`Low`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Count',
+                        'value': '`1234`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Finding',
+                        'value': 'https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2'
+                    }
                 ],
-                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                'text': 'AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_medium.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_guardduty_finding_medium.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "warning",
-                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
-                "fields": [
+                'color': 'warning',
+                'fallback': 'GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Description",
-                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`EC2 instance has an unprotected port which is being probed by a known malicious host.`'
                     },
                     {
-                        "short": False,
-                        "title": "Finding Type",
-                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                        'short': False,
+                        'title': 'Finding Type',
+                        'value': '`Recon:EC2 PortProbeUnprotectedPort`'
                     },
                     {
-                        "short": True,
-                        "title": "First Seen",
-                        "value": "`2020-01-02T01:02:03Z`",
+                        'short': True,
+                        'title': 'First Seen',
+                        'value': '`2020-01-02T01:02:03Z`'
                     },
                     {
-                        "short": True,
-                        "title": "Last Seen",
-                        "value": "`2020-01-03T01:02:03Z`",
+                        'short': True,
+                        'title': 'Last Seen',
+                        'value': '`2020-01-03T01:02:03Z`'
                     },
-                    {"short": True, "title": "Severity", "value": "`Medium`"},
-                    {"short": True, "title": "Account ID", "value": "`123456789`"},
-                    {"short": True, "title": "Count", "value": "`1234`"},
                     {
-                        "short": False,
-                        "title": "Link to Finding",
-                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`Medium`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Count',
+                        'value': '`1234`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Finding',
+                        'value': 'https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2'
+                    }
                 ],
-                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                'text': 'AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_sns_get_slack_message_payload_snapshots message_cloudwatch_alarm.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_ssm_run_command_event.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "good",
-                "fallback": "Alarm DBMigrationRequired triggered",
-                "fields": [
+                'color': 'good',
+                'fallback': 'EC2 Run Command Notification  us-east-1',
+                'fields': [
                     {
-                        "short": True,
-                        "title": "Alarm Name",
-                        "value": "`DBMigrationRequired`",
+                        'short': True,
+                        'title': 'Command Id',
+                        'value': '`6f69316a-e502-5a20-99bc-2408825b6dee`'
                     },
                     {
-                        "short": False,
-                        "title": "Alarm Description",
-                        "value": '`App is reporting "A JPA error occurred(Unable to build EntityManagerFactory)"`',
+                        'short': True,
+                        'title': 'Region',
+                        'value': '`us-east-1`'
                     },
                     {
-                        "short": False,
-                        "title": "Alarm reason",
-                        "value": "`Threshold Crossed: 1 datapoint [1.0 (12/02/19 15:44:00)] was not less than the threshold (1.0).`",
+                        'short': False,
+                        'title': 'Document Name',
+                        'value': '`AWS-RunPatchBaseline`'
                     },
-                    {"short": True, "title": "Old State", "value": "`ALARM`"},
-                    {"short": True, "title": "Current State", "value": "`OK`"},
                     {
-                        "short": False,
-                        "title": "Link to Alarm",
-                        "value": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=DBMigrationRequired",
+                        'short': False,
+                        'title': 'Instance Id',
+                        'value': '`i-99999999999999999`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Requested Time',
+                        'value': '`2023-12-14T10:48:47.127Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2023-12-14T10:52:22.114Z`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Status',
+                        'value': '`Success`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Detailed Status',
+                        'value': '`Success`'
+                    }
                 ],
-                "text": "AWS CloudWatch notification - DBMigrationRequired",
+                'text': 'EC2 Run Command Notification us-east-1'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_sns_get_slack_message_payload_snapshots message_dms_notification.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_ssm_run_command_event_failed.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "fallback": "A new message",
-                "fields": [
+                'color': 'danger',
+                'fallback': 'EC2 Run Command Notification  us-east-1',
+                'fields': [
                     {
-                        "short": True,
-                        "title": "Event Source",
-                        "value": "`replication-task`",
+                        'short': True,
+                        'title': 'Command Id',
+                        'value': '`6f69316a-e502-5a20-99bc-2408825b6dee`'
                     },
                     {
-                        "short": True,
-                        "title": "Event Time",
-                        "value": "`2019-02-12 15:45:24.091`",
+                        'short': True,
+                        'title': 'Region',
+                        'value': '`us-east-1`'
                     },
                     {
-                        "short": False,
-                        "title": "Identifier Link",
-                        "value": "`https://console.aws.amazon.com/dms/home?region=us-east-1#tasks:ids=hello-world`",
-                    },
-                    {"short": True, "title": "SourceId", "value": "`hello-world`"},
-                    {
-                        "short": False,
-                        "title": "Event ID",
-                        "value": "`http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html#DMS-EVENT-0079 `",
+                        'short': False,
+                        'title': 'Document Name',
+                        'value': '`AWS-RunPatchBaseline`'
                     },
                     {
-                        "short": False,
-                        "title": "Event Message",
-                        "value": "`Replication task has stopped.`",
+                        'short': False,
+                        'title': 'Instance Id',
+                        'value': '`i-99999999999999999`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Requested Time',
+                        'value': '`2023-12-14T10:48:47.127Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2023-12-14T10:52:22.114Z`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Status',
+                        'value': '`Failed`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Detailed Status',
+                        'value': '`Failed`'
+                    }
                 ],
-                "mrkdwn_in": ["value"],
-                "text": "AWS notification",
-                "title": "DMS Notification Message",
+                'text': 'EC2 Run Command Notification us-east-1'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_sns_get_slack_message_payload_snapshots message_glue_notification.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_ssm_run_command_event_success.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "fallback": "A new message",
-                "fields": [
-                    {"short": True, "title": "version", "value": "`0`"},
+                'color': 'good',
+                'fallback': 'EC2 Run Command Notification  us-east-1',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "id",
-                        "value": "`ad3c3da1-148c-d5da-9a6a-79f1bc9a8a2e`",
+                        'short': True,
+                        'title': 'Command Id',
+                        'value': '`6f69316a-e502-5a20-99bc-2408825b6dee`'
                     },
                     {
-                        "short": True,
-                        "title": "detail-type",
-                        "value": "`Glue Job State Change`",
+                        'short': True,
+                        'title': 'Region',
+                        'value': '`us-east-1`'
                     },
-                    {"short": True, "title": "source", "value": "`aws.glue`"},
-                    {"short": True, "title": "account", "value": "`000000000000`"},
-                    {"short": True, "title": "time", "value": "`2021-06-18T12:34:06Z`"},
-                    {"short": True, "title": "region", "value": "`us-east-2`"},
-                    {"short": True, "title": "resources", "value": "`[]`"},
                     {
-                        "short": False,
-                        "title": "detail",
-                        "value": '`{"jobName": "test_job", "severity": "ERROR", "state": "FAILED", "jobRunId": "jr_ca2144d747b45ad412d3c66a1b6934b6b27aa252be9a21a95c54dfaa224a1925", "message": "SystemExit: 1"}`',
+                        'short': False,
+                        'title': 'Document Name',
+                        'value': '`AWS-RunPatchBaseline`'
                     },
+                    {
+                        'short': False,
+                        'title': 'Instance Id',
+                        'value': '`i-99999999999999999`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Requested Time',
+                        'value': '`2023-12-14T10:48:47.127Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2023-12-14T10:52:22.114Z`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Status',
+                        'value': '`Success`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Detailed Status',
+                        'value': '`Success`'
+                    }
                 ],
-                "mrkdwn_in": ["value"],
-                "text": "AWS notification",
-                "title": "Message",
+                'text': 'EC2 Run Command Notification us-east-1'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots[
-    "test_sns_get_slack_message_payload_snapshots message_guardduty_finding.json"
-] = [
+snapshots['test_event_get_slack_message_payload_snapshots event_ssm_run_command_event_timedout.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "color": "danger",
-                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
-                "fields": [
+                'color': 'danger',
+                'fallback': 'EC2 Run Command Notification  us-east-1',
+                'fields': [
                     {
-                        "short": False,
-                        "title": "Description",
-                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                        'short': True,
+                        'title': 'Command Id',
+                        'value': '`6f69316a-e502-5a20-99bc-2408825b6dee`'
                     },
                     {
-                        "short": False,
-                        "title": "Finding Type",
-                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                        'short': True,
+                        'title': 'Region',
+                        'value': '`us-east-1`'
                     },
                     {
-                        "short": True,
-                        "title": "First Seen",
-                        "value": "`2020-01-02T01:02:03Z`",
+                        'short': False,
+                        'title': 'Document Name',
+                        'value': '`AWS-RunPatchBaseline`'
                     },
                     {
-                        "short": True,
-                        "title": "Last Seen",
-                        "value": "`2020-01-03T01:02:03Z`",
+                        'short': False,
+                        'title': 'Instance Id',
+                        'value': '`i-99999999999999999`'
                     },
-                    {"short": True, "title": "Severity", "value": "`High`"},
-                    {"short": True, "title": "Account ID", "value": "`123456789`"},
-                    {"short": True, "title": "Count", "value": "`1234`"},
                     {
-                        "short": False,
-                        "title": "Link to Finding",
-                        "value": "https://console.amazonaws-us-gov.com/guardduty/home?region=us-gov-east-1#/findings?search=id%3Dsample-id-2",
+                        'short': True,
+                        'title': 'Requested Time',
+                        'value': '`2023-12-14T10:48:47.127Z`'
                     },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2023-12-14T10:52:22.114Z`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Status',
+                        'value': '`TimedOut`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Detailed Status',
+                        'value': '`DeliveryTimedOut`'
+                    }
                 ],
-                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                'text': 'EC2 Run Command Notification us-east-1'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]
 
-snapshots["test_sns_get_slack_message_payload_snapshots message_text_message.json"] = [
+snapshots['test_sns_get_slack_message_payload_snapshots message_cloudwatch_alarm.json'] = [
     {
-        "attachments": [
+        'attachments': [
             {
-                "fallback": "A new message",
-                "fields": [
+                'color': 'good',
+                'fallback': 'Alarm DBMigrationRequired triggered',
+                'fields': [
                     {
-                        "short": False,
-                        "value": """This
+                        'short': True,
+                        'title': 'Alarm Name',
+                        'value': '`DBMigrationRequired`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Alarm Description',
+                        'value': '`App is reporting "A JPA error occurred(Unable to build EntityManagerFactory)"`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Alarm reason',
+                        'value': '`Threshold Crossed: 1 datapoint [1.0 (12/02/19 15:44:00)] was not less than the threshold (1.0).`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Old State',
+                        'value': '`ALARM`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Current State',
+                        'value': '`OK`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Alarm',
+                        'value': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=DBMigrationRequired'
+                    }
+                ],
+                'text': 'AWS CloudWatch notification - DBMigrationRequired'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_dms_notification.json'] = [
+    {
+        'attachments': [
+            {
+                'fallback': 'A new message',
+                'fields': [
+                    {
+                        'short': True,
+                        'title': 'Event Source',
+                        'value': '`replication-task`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2019-02-12 15:45:24.091`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Identifier Link',
+                        'value': '`https://console.aws.amazon.com/dms/home?region=us-east-1#tasks:ids=hello-world`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'SourceId',
+                        'value': '`hello-world`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Event ID',
+                        'value': '`http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html#DMS-EVENT-0079 `'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Event Message',
+                        'value': '`Replication task has stopped.`'
+                    }
+                ],
+                'mrkdwn_in': [
+                    'value'
+                ],
+                'text': 'AWS notification',
+                'title': 'DMS Notification Message'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_glue_notification.json'] = [
+    {
+        'attachments': [
+            {
+                'fallback': 'A new message',
+                'fields': [
+                    {
+                        'short': True,
+                        'title': 'version',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'id',
+                        'value': '`ad3c3da1-148c-d5da-9a6a-79f1bc9a8a2e`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'detail-type',
+                        'value': '`Glue Job State Change`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'source',
+                        'value': '`aws.glue`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'account',
+                        'value': '`000000000000`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'time',
+                        'value': '`2021-06-18T12:34:06Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'region',
+                        'value': '`us-east-2`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'resources',
+                        'value': '`[]`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'detail',
+                        'value': '`{"jobName": "test_job", "severity": "ERROR", "state": "FAILED", "jobRunId": "jr_ca2144d747b45ad412d3c66a1b6934b6b27aa252be9a21a95c54dfaa224a1925", "message": "SystemExit: 1"}`'
+                    }
+                ],
+                'mrkdwn_in': [
+                    'value'
+                ],
+                'text': 'AWS notification',
+                'title': 'Message'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_guardduty_finding.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'danger',
+                'fallback': 'GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`EC2 instance has an unprotected port which is being probed by a known malicious host.`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding Type',
+                        'value': '`Recon:EC2 PortProbeUnprotectedPort`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'First Seen',
+                        'value': '`2020-01-02T01:02:03Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Last Seen',
+                        'value': '`2020-01-03T01:02:03Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`High`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Count',
+                        'value': '`1234`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to Finding',
+                        'value': 'https://console.amazonaws-us-gov.com/guardduty/home?region=us-gov-east-1#/findings?search=id%3Dsample-id-2'
+                    }
+                ],
+                'text': 'AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_ssm_run_command_event.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'good',
+                'fallback': 'EC2 Run Command Notification  us-east-1',
+                'fields': [
+                    {
+                        'short': True,
+                        'title': 'Command Id',
+                        'value': '`6f69316a-e502-5a20-99bc-2408825b6dee`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Region',
+                        'value': '`us-east-1`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Document Name',
+                        'value': '`AWS-RunPatchBaseline`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Instance Id',
+                        'value': '`i-99999999999999999`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Requested Time',
+                        'value': '`2023-12-14T10:48:47.127Z`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Event Time',
+                        'value': '`2023-12-14T10:52:22.114Z`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Status',
+                        'value': '`Success`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Detailed Status',
+                        'value': '`Success`'
+                    }
+                ],
+                'text': 'EC2 Run Command Notification us-east-1'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_text_message.json'] = [
+    {
+        'attachments': [
+            {
+                'fallback': 'A new message',
+                'fields': [
+                    {
+                        'short': False,
+                        'value': '''This
 is
 a typical multi-line
 message from SNS!
 
-Have a ~good~ amazing day! :)""",
+Have a ~good~ amazing day! :)'''
                     }
                 ],
-                "mrkdwn_in": ["value"],
-                "text": "AWS notification",
-                "title": "All Fine",
+                'mrkdwn_in': [
+                    'value'
+                ],
+                'text': 'AWS notification',
+                'title': 'All Fine'
             }
         ],
-        "channel": "slack_testing_sandbox",
-        "icon_emoji": ":aws:",
-        "username": "notify_slack_test",
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
     }
 ]


### PR DESCRIPTION
## Description
AWS System Manager Run Command notifications formatting was added to the script. Now it is possible to configure System Manager Run Command to send messages to the SNS topic and messages will be formatted and sent to the slack channel.

## Motivation and Context
It is a new feature that allows formatting the AWS System Manager Run Command notifications.

## Breaking Changes
No breaking changes in this PR

## How Has This Been Tested?
- I have tested and validated these changes using new events added to the `functions/events` folder
- I have executed `pre-commit run -a` on my pull request
