### PR TITLE
feat: Add ignore_source_code_hash variable and pass to lambda module

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | A unique role name beginning with the specified prefix | `string` | `"lambda"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Additional tags for the IAM role | `map(string)` | `{}` | no |
+| <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for decrypting slack webhook url | `string` | `""` | no |
 | <a name="input_lambda_attach_dead_letter_policy"></a> [lambda\_attach\_dead\_letter\_policy](#input\_lambda\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | <a name="input_lambda_dead_letter_target_arn"></a> [lambda\_dead\_letter\_target\_arn](#input\_lambda\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -87,15 +87,16 @@ module "lambda" {
   function_name = var.lambda_function_name
   description   = var.lambda_description
 
-  hash_extra                     = var.hash_extra
-  handler                        = "${local.lambda_handler}.lambda_handler"
-  source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
-  recreate_missing_package       = var.recreate_missing_package
-  runtime                        = "python3.8"
-  timeout                        = 30
-  kms_key_arn                    = var.kms_key_arn
-  reserved_concurrent_executions = var.reserved_concurrent_executions
   ephemeral_storage_size         = var.lambda_function_ephemeral_storage_size
+  handler                        = "${local.lambda_handler}.lambda_handler"
+  hash_extra                     = var.hash_extra
+  ignore_source_code_hash        = var.ignore_source_code_hash
+  kms_key_arn                    = var.kms_key_arn
+  recreate_missing_package       = var.recreate_missing_package
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  runtime                        = "python3.8"
+  source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
+  timeout                        = 30
 
   # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack:
   # InvalidParameterValueException: We currently do not support adding policies for $LATEST."

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "hash_extra" {
   default     = ""
 }
 
+variable "ignore_source_code_hash" {
+  description = "Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately."
+  type        = bool
+  default     = false
+}
+
 variable "lambda_role" {
   description = "IAM role attached to the Lambda Function.  If this is set then a role will not be created for you."
   type        = string


### PR DESCRIPTION
## Description
This feature adds the variable `ignore_source_code_hash` and passes it to the Lambda child module call.

## Motivation and Context
When implementing `hash_extra` I was experiencing issues described in this issue: https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/330

When `ignore_source_code_hash = true` is utilized, we are able to work around these issues.

## Breaking Changes
None, defaults to false.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
