### PR TITLE
feat: Support for lambda code signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you want to subscribe the AWS Lambda Function created by this module to an ex
 ## Examples
 
 - [notify-slack-simple](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/tree/master/examples/notify-slack-simple) - Creates SNS topic which sends messages to Slack channel.
+- [notify-slack-signed-code](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/tree/master/examples/notify-slack-signed-code) - Creates SNS topic and lambda with signed code which sends messages to Slack channel.
 - [cloudwatch-alerts-to-slack](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/tree/master/examples/cloudwatch-alerts-to-slack) - End to end example which shows how to send AWS Cloudwatch alerts to Slack channel and use KMS to encrypt webhook URL.
 
 ## Local Development and Testing

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.2.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 6.5.0 |
 
 ## Resources
 
@@ -102,6 +102,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_cloudwatch_log_group_tags"></a> [cloudwatch\_log\_group\_tags](#input\_cloudwatch\_log\_group\_tags) | Additional tags for the Cloudwatch log group | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create all resources | `bool` | `true` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create new SNS topic | `bool` | `true` | no |
+| <a name="input_custom_lambda_source_name"></a> [custom\_lambda\_source\_name](#input\_custom\_lambda\_source\_name) | The name of the custom Lambda function source file without the extension when using s3\_existing\_package. | `string` | `null` | no |
 | <a name="input_enable_sns_topic_delivery_status_logs"></a> [enable\_sns\_topic\_delivery\_status\_logs](#input\_enable\_sns\_topic\_delivery\_status\_logs) | Whether to enable SNS topic delivery status logs | `bool` | `false` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | Path of policies to that should be added to IAM role for Lambda Function | `string` | `null` | no |
@@ -113,6 +114,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_lambda_attach_dead_letter_policy"></a> [lambda\_attach\_dead\_letter\_policy](#input\_lambda\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | <a name="input_lambda_dead_letter_target_arn"></a> [lambda\_dead\_letter\_target\_arn](#input\_lambda\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
 | <a name="input_lambda_description"></a> [lambda\_description](#input\_lambda\_description) | The description of the Lambda function | `string` | `null` | no |
+| <a name="input_lambda_function_code_signing_config_arn"></a> [lambda\_function\_code\_signing\_config\_arn](#input\_lambda\_function\_code\_signing\_config\_arn) | Amazon Resource Name (ARN) of the Lambda Code Signing Configuration | `string` | `null` | no |
 | <a name="input_lambda_function_ephemeral_storage_size"></a> [lambda\_function\_ephemeral\_storage\_size](#input\_lambda\_function\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
 | <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | The name of the Lambda function to create | `string` | `"notify_slack"` | no |
 | <a name="input_lambda_function_s3_bucket"></a> [lambda\_function\_s3\_bucket](#input\_lambda\_function\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
@@ -126,6 +128,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |
+| <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | The name of the channel in Slack for notifications | `string` | n/a | yes |
 | <a name="input_slack_emoji"></a> [slack\_emoji](#input\_slack\_emoji) | A custom emoji that will appear on Slack messages | `string` | `":aws:"` | no |
 | <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | The username that will appear on Slack messages | `string` | n/a | yes |

--- a/examples/notify-slack-signed-code/README.md
+++ b/examples/notify-slack-signed-code/README.md
@@ -1,0 +1,77 @@
+Slack notification with Code Signing
+====================================
+
+Configuration in this directory creates an SNS topic that sends messages to a Slack channel.
+
+Note, this example does not use KMS key.
+
+Usage
+=====
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.4.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_lambda_code_signing_config.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_code_signing_config) | resource |
+| [aws_s3_bucket.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_versioning.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_object.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_signer_signing_job.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/signer_signing_job) | resource |
+| [aws_signer_signing_profile.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/signer_signing_profile) | resource |
+| [aws_sns_topic.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [local_file.integration_testing](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [archive_file.example](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The Amazon Resource Name (ARN) specifying the log group |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | The ARN of the IAM role used by Lambda function |
+| <a name="output_lambda_iam_role_name"></a> [lambda\_iam\_role\_name](#output\_lambda\_iam\_role\_name) | The name of the IAM role used by Lambda function |
+| <a name="output_notify_slack_lambda_function_arn"></a> [notify\_slack\_lambda\_function\_arn](#output\_notify\_slack\_lambda\_function\_arn) | The ARN of the Lambda function |
+| <a name="output_notify_slack_lambda_function_invoke_arn"></a> [notify\_slack\_lambda\_function\_invoke\_arn](#output\_notify\_slack\_lambda\_function\_invoke\_arn) | The ARN to be used for invoking Lambda function from API Gateway |
+| <a name="output_notify_slack_lambda_function_last_modified"></a> [notify\_slack\_lambda\_function\_last\_modified](#output\_notify\_slack\_lambda\_function\_last\_modified) | The date Lambda function was last modified |
+| <a name="output_notify_slack_lambda_function_name"></a> [notify\_slack\_lambda\_function\_name](#output\_notify\_slack\_lambda\_function\_name) | The name of the Lambda function |
+| <a name="output_notify_slack_lambda_function_version"></a> [notify\_slack\_lambda\_function\_version](#output\_notify\_slack\_lambda\_function\_version) | Latest published version of your Lambda function |
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The ARN of the SNS topic from which messages will be sent to Slack |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/notify-slack-signed-code/data.tf
+++ b/examples/notify-slack-signed-code/data.tf
@@ -1,0 +1,7 @@
+data "aws_caller_identity" "current" {}
+
+data "archive_file" "example" {
+  type        = "zip"
+  source_file = "${local.functions_path}/${local.source_filename}"
+  output_path = "./${local.source_filename}.zip"
+}

--- a/examples/notify-slack-signed-code/main.tf
+++ b/examples/notify-slack-signed-code/main.tf
@@ -1,0 +1,119 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
+  region = "eu-west-1"
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+  functions_path  = "../../functions"
+  source_filename = "notify_slack.py"
+  s3_bucket_name  = "${data.aws_caller_identity.current.account_id}-${local.name}"
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+resource "aws_sns_topic" "example" {
+  name = local.name
+  tags = local.tags
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket        = local.s3_bucket_name
+  force_destroy = true
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "example" {
+  bucket = aws_s3_bucket.example.id
+  key    = replace(data.archive_file.example.output_path, "./", "")
+  source = data.archive_file.example.output_path
+}
+
+resource "aws_signer_signing_profile" "example" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+}
+
+resource "aws_signer_signing_job" "example" {
+  profile_name = aws_signer_signing_profile.example.name
+
+  source {
+    s3 {
+      bucket  = aws_s3_bucket.example.id
+      key     = aws_s3_object.example.id
+      version = aws_s3_object.example.version_id
+    }
+  }
+
+  destination {
+    s3 {
+      bucket = aws_s3_bucket.example.id
+    }
+  }
+
+  ignore_signing_job_failure = false
+}
+
+resource "aws_lambda_code_signing_config" "example" {
+  allowed_publishers {
+    signing_profile_version_arns = [
+      aws_signer_signing_profile.example.version_arn,
+    ]
+  }
+
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
+}
+
+################################################################################
+# Slack Notify Module
+################################################################################
+
+module "notify_slack" {
+  source = "../../"
+
+  sns_topic_name   = aws_sns_topic.example.name
+  create_sns_topic = false
+
+  lambda_function_code_signing_config_arn = aws_lambda_code_signing_config.example.arn
+  custom_lambda_source_name               = replace(local.source_filename, ".py", "")
+
+  s3_existing_package = {
+    bucket = aws_signer_signing_job.example.signed_object[0].s3[0].bucket
+    key    = aws_signer_signing_job.example.signed_object[0].s3[0].key
+  }
+
+  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
+  slack_channel     = "aws-notification"
+  slack_username    = "reporter"
+
+  tags = local.tags
+}
+
+################################################################################
+# Integration Testing Support
+# This populates a file that is gitignored to aid in executing the integration tests locally
+################################################################################
+
+resource "local_file" "integration_testing" {
+  filename = "${path.module}/../../functions/.int.env"
+  content  = <<-EOT
+    REGION=${local.region}
+    LAMBDA_FUNCTION_NAME=${module.notify_slack.notify_slack_lambda_function_name}
+    SNS_TOPIC_ARN=${aws_sns_topic.example.arn}
+    EOT
+}

--- a/examples/notify-slack-signed-code/outputs.tf
+++ b/examples/notify-slack-signed-code/outputs.tf
@@ -1,0 +1,44 @@
+output "sns_topic_arn" {
+  description = "The ARN of the SNS topic from which messages will be sent to Slack"
+  value       = module.notify_slack.slack_topic_arn
+}
+
+output "lambda_iam_role_arn" {
+  description = "The ARN of the IAM role used by Lambda function"
+  value       = module.notify_slack.lambda_iam_role_arn
+}
+
+output "lambda_iam_role_name" {
+  description = "The name of the IAM role used by Lambda function"
+  value       = module.notify_slack.lambda_iam_role_name
+}
+
+output "notify_slack_lambda_function_arn" {
+  description = "The ARN of the Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_arn
+}
+
+output "notify_slack_lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_name
+}
+
+output "notify_slack_lambda_function_invoke_arn" {
+  description = "The ARN to be used for invoking Lambda function from API Gateway"
+  value       = module.notify_slack.notify_slack_lambda_function_invoke_arn
+}
+
+output "notify_slack_lambda_function_last_modified" {
+  description = "The date Lambda function was last modified"
+  value       = module.notify_slack.notify_slack_lambda_function_last_modified
+}
+
+output "notify_slack_lambda_function_version" {
+  description = "Latest published version of your Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_version
+}
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = module.notify_slack.lambda_cloudwatch_log_group_arn
+}

--- a/examples/notify-slack-signed-code/versions.tf
+++ b/examples/notify-slack-signed-code/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.8"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4.1"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "hash_extra" {
   default     = ""
 }
 
+variable "lambda_function_code_signing_config_arn" {
+  description = "Amazon Resource Name (ARN) of the Lambda Code Signing Configuration"
+  type        = string
+  default     = null
+}
+
 variable "lambda_role" {
   description = "IAM role attached to the Lambda Function.  If this is set then a role will not be created for you."
   type        = string
@@ -42,6 +48,12 @@ variable "lambda_description" {
 
 variable "lambda_source_path" {
   description = "The source path of the custom Lambda function"
+  type        = string
+  default     = null
+}
+
+variable "custom_lambda_source_name" {
+  description = "The name of the custom Lambda function source file without the extension when using s3_existing_package."
   type        = string
   default     = null
 }
@@ -142,6 +154,12 @@ variable "slack_emoji" {
   description = "A custom emoji that will appear on Slack messages"
   type        = string
   default     = ":aws:"
+}
+
+variable "s3_existing_package" {
+  description = "The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use"
+  type        = map(string)
+  default     = null
 }
 
 variable "kms_key_arn" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes:
1. Updated `lambda_handler` local variable.
2. Update `source_path` input for module lambda.
Ensure that `source_path` is null when `s3_existing_package` is set and `lambda_source_path` is null. Previously this is set to `./functions/notify_slack.py` if `lambda_source_path` is not set.
3. Added attribute `code_signing_config_arn` in module lambda.
Needed to attach the code signing config to the lambda.
4. Added 3 new variables `lambda_code_signing_config_arn`, `custom_lambda_source_name`, `s3_existing_package`.
5. Bump `terraform-aws-modules/lambda/aws` to version 6.5.0 for `code_signing_config_arn`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have a requirement to secure the lambdas provisioned in our AWS account with code signing. This introduce support for deploying this module with lambda code signing enforced.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking of backwards compatibility.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
