### PR TITLE
feat: Get Slack Webhook URL from the Amazon Secret Manager

### DIFF
--- a/examples/notify-slack-simple/main.tf
+++ b/examples/notify-slack-simple/main.tf
@@ -30,9 +30,10 @@ module "notify_slack" {
   sns_topic_name   = aws_sns_topic.example.name
   create_sns_topic = false
 
-  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
-  slack_channel     = "aws-notification"
-  slack_username    = "reporter"
+  slack_webhook_url            = ""
+  slack_webhook_url_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789000:secret:slack-webhook-url-XXXXXX"
+  slack_channel                = "aws-notification"
+  slack_username               = "reporter"
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
 }
 
 data "aws_secretsmanager_secret_version" "slack_webhook_url" {
-  count = var.slack_webhook_url_secret_arn != "" ? 1 : 0
+  count     = var.slack_webhook_url_secret_arn != "" ? 1 : 0
   secret_id = var.slack_webhook_url_secret_arn
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -124,8 +124,16 @@ variable "sns_topic_lambda_feedback_sample_rate" {
 }
 
 variable "slack_webhook_url" {
-  description = "The URL of Slack webhook"
+  description = "The Slack webhook URL directly provided. Leave empty if using secret ARN."
   type        = string
+  sensitive   = true
+}
+
+variable "slack_webhook_url_secret_arn" {
+  description = "The ARN of the secret in AWS Secrets Manager containing the Slack webhook URL. Leave empty if the URL is directly provided."
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "slack_channel" {


### PR DESCRIPTION
## Description
As Slack webhook URL is considered sensitive information, it would be great to get the possibility to retrieve its value from the Secret Manager. Also, to enhance the module security, we can mask the sensitive variables with a `sensitive=true` flag. This will give us the possibility to execute this module in CI/CD, without been exposed.

## Motivation and Context
Improve security and protect sensitive variables. 

## Breaking Changes
No breaking changes were introduced.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate
- [x] I have tested the module with my owd Terragrunt configuration
