### PR TITLE
fix: Correct assume role permissions for SNS service to assume IAM role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.4
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/iam.tf
+++ b/iam.tf
@@ -6,21 +6,14 @@ data "aws_iam_policy_document" "sns_feedback" {
   count = local.create_sns_feedback_role ? 1 : 0
 
   statement {
-    sid    = "PermitDeliveryStatusMessagesToCloudWatchLogs"
+    sid    = "SnsAssume"
     effect = "Allow"
 
     actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:PutMetricFilter",
-      "logs:PutRetentionPolicy",
-      "sts:AssumeRole"
+      "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
-    resources = [
-      "*"
-    ]
     principals {
       type        = "Service"
       identifiers = ["sns.amazonaws.com"]
@@ -37,5 +30,9 @@ resource "aws_iam_role" "sns_feedback_role" {
   force_detach_policies = var.sns_topic_feedback_role_force_detach_policies
   permissions_boundary  = var.sns_topic_feedback_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.sns_feedback[0].json
-  tags                  = merge(var.tags, var.sns_topic_feedback_role_tags)
+
+  tags = merge(
+    var.tags,
+    var.sns_topic_feedback_role_tags,
+  )
 }

--- a/iam.tf
+++ b/iam.tf
@@ -31,7 +31,16 @@ resource "aws_iam_role" "sns_feedback_role" {
   path                  = var.sns_topic_feedback_role_path
   force_detach_policies = var.sns_topic_feedback_role_force_detach_policies
   permissions_boundary  = var.sns_topic_feedback_role_permissions_boundary
-  assume_role_policy    = data.aws_iam_policy_document.sns_feedback[0].json
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = {
+        Service = "sns.amazonaws.com"
+      },
+      Action    = "sts:AssumeRole"
+    }]
+  })
 
   tags = merge(var.tags, var.sns_topic_feedback_role_tags)
 }

--- a/iam.tf
+++ b/iam.tf
@@ -14,12 +14,17 @@ data "aws_iam_policy_document" "sns_feedback" {
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:PutMetricFilter",
-      "logs:PutRetentionPolicy"
+      "logs:PutRetentionPolicy",
+      "sts:AssumeRole"
     ]
 
     resources = [
       "*"
     ]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
   }
 }
 
@@ -31,16 +36,6 @@ resource "aws_iam_role" "sns_feedback_role" {
   path                  = var.sns_topic_feedback_role_path
   force_detach_policies = var.sns_topic_feedback_role_force_detach_policies
   permissions_boundary  = var.sns_topic_feedback_role_permissions_boundary
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect    = "Allow",
-      Principal = {
-        Service = "sns.amazonaws.com"
-      },
-      Action    = "sts:AssumeRole"
-    }]
-  })
-
-  tags = merge(var.tags, var.sns_topic_feedback_role_tags)
+  assume_role_policy    = data.aws_iam_policy_document.sns_feedback[0].json
+  tags                  = merge(var.tags, var.sns_topic_feedback_role_tags)
 }


### PR DESCRIPTION
## Description

Replaced the defined `assume_role_policy` with an inline policy and with that the IAM policy for CloudWatch Logs is properly attached to the role, and a valid assume role policy is defined, granting AWS SNS the right to assume the role.

## Motivation and Context
Fixes #219 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
