### PR TITLE
feat: Update Python lambda runtime from `3.8` to `3.11`

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pipenv
         run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
 
 ## Supported Features
 
-- AWS Lambda runtime Python 3.8
+- AWS Lambda runtime Python 3.11
 - Create new SNS topic or use existing one
 - Support plaintext and encrypted version of Slack webhook URL
 - Most of Slack message options are customizable
@@ -17,7 +17,6 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
   - AWS CloudWatch Alarms
   - AWS CloudWatch LogMetrics Alarms
   - AWS GuardDuty Findings
-
 
 ## Usage
 
@@ -38,11 +37,11 @@ module "notify_slack" {
 
 [Terraform Cloud Agents](https://www.terraform.io/docs/cloud/workspaces/agent.html) are a paid feature, available as part of the Terraform Cloud for Business upgrade package.
 
-This module requires Python 3.8. You can customize [tfc-agent](https://hub.docker.com/r/hashicorp/tfc-agent) to include Python using this sample `Dockerfile`:
+This module requires Python 3.11. You can customize [tfc-agent](https://hub.docker.com/r/hashicorp/tfc-agent) to include Python using this sample `Dockerfile`:
 
-```
+```Dockerfile
 FROM hashicorp/tfc-agent:latest
-RUN apt-get -y update && apt-get -y install python3.8 python3-pip
+RUN apt-get -y update && apt-get -y install python3.11 python3-pip
 ENTRYPOINT ["/bin/tfc-agent"]
 ```
 

--- a/functions/.pyproject.toml
+++ b/functions/.pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py311']
 include = '\.pyi?$'
 verbose = true
 exclude = '''

--- a/functions/Pipfile
+++ b/functions/Pipfile
@@ -6,8 +6,8 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-boto3 = "~=1.20"
-botocore = "~=1.23"
+boto3 = "~=1.34"
+botocore = "~=1.34"
 black = "*"
 flake8 = "*"
 isort = "*"
@@ -18,7 +18,7 @@ radon = "*"
 snapshottest = "~=0.6"
 
 [requires]
-python_version = "3.8"
+python_version = "3.11"
 
 [scripts]
 test = "python3 -m pytest --cov --cov-report=term"

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ module "lambda" {
   handler                        = "${local.lambda_handler}.lambda_handler"
   source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
   recreate_missing_package       = var.recreate_missing_package
-  runtime                        = "python3.8"
+  runtime                        = "python3.11"
   architectures                  = var.architectures
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn


### PR DESCRIPTION
## Description
- Update Python lambda runtime from `3.8` to `3.11`
	- I tried `3.12` but there is more work involved there to support that so this seemed like a good compromise 

## Motivation and Context
- Python 3.8 runtime is deprecated and will be EOL later this year
- Resolves #217 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
