### PR TITLE
fix: Update `aws_sns_topic_subscription` endpoint to use qualified arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.2.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 6.8.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -73,14 +73,14 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
   topic_arn           = local.sns_topic_arn
   protocol            = "lambda"
-  endpoint            = module.lambda.lambda_function_arn
+  endpoint            = module.lambda.lambda_function_qualified_arn
   filter_policy       = var.subscription_filter_policy
   filter_policy_scope = var.subscription_filter_policy_scope
 }
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "3.2.0"
+  version = "6.8.0"
 
   create = var.create
 


### PR DESCRIPTION
## Description
This commit updates the `aws_sns_topic_subscription` resource to use the `lambda_function_qualified_arn` output for the `endpoint` value.

Also bump the `lambda` module to `6.8.0`, which is the latest version that maintains compatability with `aws` v4 provider.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #230

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
