### PR TITLE
feat: Add variable to allow disabling the package timestamp trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_subscription_filter_policy"></a> [subscription\_filter\_policy](#input\_subscription\_filter\_policy) | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
 | <a name="input_subscription_filter_policy_scope"></a> [subscription\_filter\_policy\_scope](#input\_subscription\_filter\_policy\_scope) | (Optional) A valid filter policy scope MessageAttributes\|MessageBody | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_trigger_on_package_timestamp"></a> [trigger\_on\_package\_timestamp](#input\_trigger\_on\_package\_timestamp) | (Optional) Whether or not to ignore the file timestamp when deciding to create the archive | `bool` | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ module "lambda" {
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions
   ephemeral_storage_size         = var.lambda_function_ephemeral_storage_size
+  trigger_on_package_timestamp   = var.trigger_on_package_timestamp
 
   # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack:
   # InvalidParameterValueException: We currently do not support adding policies for $LATEST."

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "subscription_filter_policy_scope" {
   type        = string
   default     = null
 }
+
+variable "trigger_on_package_timestamp" {
+  description = "(Optional) Whether or not to ignore the file timestamp when deciding to create the archive"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description
This adds a variable (default false) for triggering an update of the underlying lambda based on the timestamp of the underlying file

## Motivation and Context
This fixes the case where this module is used and automatically planned/applied from CI, where the source is freshly copied/cloned - currently, the module will always attempt to update the lambda in this case!

Fixes #232

## Breaking Changes
~~This does bump the underlying `terraform-aws-modules/terraform-aws-lambda` version from `3.2.0` -> `6.7.0` (the minimum that supports this option) - but the only breaking changes I can see from that are that only `terraform >= 1` is supported, and it requires a slightly newer AWS provider~~
This originally bumped the version of the lambda module from `3.2.0` -> `6.7.0` - but master has changed to `6.8.0`!

## How Has This Been Tested?
I have used this in my fork of the repo to deploy a few times within my CI pipelines
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
