### PR TITLE
fix: give SNS feedback access to CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns_feedback_allow_log_creation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/iam.tf
+++ b/iam.tf
@@ -21,6 +21,22 @@ data "aws_iam_policy_document" "sns_feedback" {
   }
 }
 
+data "aws_iam_policy_document" "sns_feedback_allow_log_creation" {
+  count = local.create_sns_feedback_role ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutMetricFilter",
+      "logs:PutRetentionPolicy",
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_role" "sns_feedback_role" {
   count = local.create_sns_feedback_role ? 1 : 0
 
@@ -30,6 +46,11 @@ resource "aws_iam_role" "sns_feedback_role" {
   force_detach_policies = var.sns_topic_feedback_role_force_detach_policies
   permissions_boundary  = var.sns_topic_feedback_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.sns_feedback[0].json
+
+  inline_policy {
+    name   = "allow-log-creation"
+    policy = data.aws_iam_policy_document.sns_feedback_allow_log_creation[0].json
+  }
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- The SNS feedback role needs both (a) allow SNS to assume the role, and (b) allow writing to CloudWatch
- This PR adds (b)

## Motivation and Context
- Fixes #236
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
