### PR TITLE
fix: Reverts endpoint variable change from e95cde8

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
   topic_arn           = local.sns_topic_arn
   protocol            = "lambda"
-  endpoint            = module.lambda.lambda_function_qualified_arn
+  endpoint            = module.lambda.lambda_function_arn
   filter_policy       = var.subscription_filter_policy
   filter_policy_scope = var.subscription_filter_policy_scope
 }


### PR DESCRIPTION
## Description
Reverts a change made in https://github.com/terraform-aws-modules/terraform-aws-notify-slack/commit/e95cde8acdaf221e74595daa2238b75f0682ea06 where a variable was changed, breaking SNS topic subscriptions.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/238 

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
