### PR TITLE
chore: Added the option to allow modification of sns access policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.sns_feedback_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.sns_notify_slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -130,6 +131,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_slack_emoji"></a> [slack\_emoji](#input\_slack\_emoji) | A custom emoji that will appear on Slack messages | `string` | `":aws:"` | no |
 | <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | The username that will appear on Slack messages | `string` | n/a | yes |
 | <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | The URL of Slack webhook | `string` | n/a | yes |
+| <a name="input_sns_topic_access_policy"></a> [sns\_topic\_access\_policy](#input\_sns\_topic\_access\_policy) | The JSON of the SNS topic policy, if any | `string` | `""` | no |
 | <a name="input_sns_topic_feedback_role_description"></a> [sns\_topic\_feedback\_role\_description](#input\_sns\_topic\_feedback\_role\_description) | Description of IAM role to use for SNS topic delivery status logging | `string` | `null` | no |
 | <a name="input_sns_topic_feedback_role_force_detach_policies"></a> [sns\_topic\_feedback\_role\_force\_detach\_policies](#input\_sns\_topic\_feedback\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
 | <a name="input_sns_topic_feedback_role_name"></a> [sns\_topic\_feedback\_role\_name](#input\_sns\_topic\_feedback\_role\_name) | Name of the IAM role to use for SNS topic delivery status logging | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,8 @@ locals {
   }
 
   lambda_handler = try(split(".", basename(var.lambda_source_path))[0], "notify_slack")
+
+  lambda_role_name = var.iam_role_name_prefix != "" ? "${var.iam_role_name_prefix}-${var.lambda_function_name}" : var.lambda_function_name
 }
 
 data "aws_iam_policy_document" "lambda" {
@@ -120,7 +122,7 @@ module "lambda" {
 
   create_role               = var.lambda_role == ""
   lambda_role               = var.lambda_role
-  role_name                 = "${var.iam_role_name_prefix}-${var.lambda_function_name}"
+  role_name                 = local.lambda_role_name
   role_permissions_boundary = var.iam_role_boundary_policy_arn
   role_tags                 = var.iam_role_tags
   role_path                 = var.iam_role_path

--- a/main.tf
+++ b/main.tf
@@ -141,12 +141,12 @@ module "lambda" {
   dead_letter_target_arn    = var.lambda_dead_letter_target_arn
   attach_dead_letter_policy = var.lambda_attach_dead_letter_policy
 
-  allowed_triggers = {
+  allowed_triggers = merge({
     AllowExecutionFromSNS = {
       principal  = "sns.amazonaws.com"
       source_arn = local.sns_topic_arn
     }
-  }
+  }, var.lambda_extra_allowed_triggers)
 
   store_on_s3 = var.lambda_function_store_on_s3
   s3_bucket   = var.lambda_function_s3_bucket

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,13 @@ resource "aws_sns_topic" "this" {
   tags = merge(var.tags, var.sns_topic_tags)
 }
 
+resource "aws_sns_topic_policy" "access_policy" {
+  count = var.create && var.sns_topic_access_policy != "" ? 1 : 0
+
+  arn    = local.sns_topic_arn
+  policy = var.sns_topic_access_policy
+}
+
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
   count = var.create ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -264,6 +264,12 @@ variable "lambda_function_ephemeral_storage_size" {
   default     = 512
 }
 
+variable "lambda_extra_allowed_triggers" {
+  description = "To allow other resources to trigger this lambda"
+  type        = map(any)
+  default     = {}
+}
+
 variable "sns_topic_tags" {
   description = "Additional tags for the SNS topic"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable "sns_topic_name" {
   type        = string
 }
 
+variable "sns_topic_access_policy" {
+  description = "The JSON of the SNS topic policy, if any"
+  type        = string
+  default     = ""
+}
+
 variable "sns_topic_kms_key_id" {
   description = "ARN of the KMS key used for enabling SSE on the topic"
   type        = string


### PR DESCRIPTION
## Description
Modified the main.tf and variables.tf to add input sns_topic_access_policy

## Motivation and Context
Reason being, some other services such as AWS backup need to be added to the access policy, so the service can trigger the SNS.
by default 

## Breaking Changes
no

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request