### PR TITLE
feat: Configure log levels

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -453,8 +453,8 @@ def lambda_handler(event: Dict[str, Any], context: Dict[str, Any]) -> str:
     :param context: lambda expected context object
     :returns: none
     """
-    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+    log_level = os.environ.get("LOG_LEVEL", "WARN").upper()
+    logging.basicConfig(level=getattr(logging, log_level, logging.WARN))
 
     if os.environ.get("LOG_EVENTS", "False") == "True":
         logging.info(f"Event logging enabled: `{json.dumps(event)}`")

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -453,6 +453,9 @@ def lambda_handler(event: Dict[str, Any], context: Dict[str, Any]) -> str:
     :param context: lambda expected context object
     :returns: none
     """
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+
     if os.environ.get("LOG_EVENTS", "False") == "True":
         logging.info(f"Event logging enabled: `{json.dumps(event)}`")
 

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,12 @@ variable "log_events" {
   default     = false
 }
 
+variable "log_level" {
+  description = "The log level for the Lambda function"
+  type        = string
+  default     = "WARN"
+}
+
 variable "reserved_concurrent_executions" {
   description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations"
   type        = number


### PR DESCRIPTION
## Description
Configure log levels, defaults to WARN. This way LOG_EVENTS is useless. 

## Motivation and Context
I was required to have the incoming event but was unable to obtain it without modifying the source code. Allowing us to set the log levels would also allow logging the incoming event

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
