### PR TITLE
fix: Modify logging for security inspector issue

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -454,7 +454,7 @@ def lambda_handler(event: Dict[str, Any], context: Dict[str, Any]) -> str:
     :returns: none
     """
     if os.environ.get("LOG_EVENTS", "False") == "True":
-        logging.info(f"Event logging enabled: `{json.dumps(event)}`")
+        logging.info("Event logging enabled: %s", json.dumps(event))
 
     for record in event["Records"]:
         sns = record["Sns"]


### PR DESCRIPTION
## Description
Logging is being flagged by AWS Inspector for log injection

## Motivation and Context
Log injection fix

## Breaking Changes
No

## How Has This Been Tested?
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Veriified by updating on existing lambda and seeing the lambda issue clear in Inspector
- [ x] I have executed `pre-commit run -a` on my pull request

