### PR TITLE
chore(runtime): remove hardcoded value for runtime

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "lambda" {
   handler                        = "${local.lambda_handler}.lambda_handler"
   source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
   recreate_missing_package       = var.recreate_missing_package
-  runtime                        = "python3.11"
+  runtime                        = var.runtime
   architectures                  = var.architectures
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn

--- a/variables.tf
+++ b/variables.tf
@@ -287,3 +287,9 @@ variable "trigger_on_package_timestamp" {
   type        = bool
   default     = false
 }
+
+variable "runtime" {
+  description = "Lambda Function runtime"
+  type        = string
+  default     = "python3.11"
+}


### PR DESCRIPTION
## Description

When its required to update the runtime version, unable to update it as its hardcoded. 

```tf
module "lambda" {
  runtime                        = "python3.11"
}
```

If your request is for a new feature, please use the `Feature request` template.

- [x] ✋ I have searched the open/closed issues and my issue is not listed.

## ⚠️ Note

Before you submit an issue, please perform the following first:

1. Remove the local `.terraform` directory (! ONLY if state is stored remotely, which hopefully you are following that best practice!): `rm -rf .terraform/`
2. Re-initialize the project root to pull down modules: `terraform init`
3. Re-attempt your terraform plan or apply and check if the issue still persists

## Versions

- Module version [Required]:
  source  = "terraform-aws-modules/notify-slack/aws"
  version = "6.5.0"
- Terraform version: 1.11.3

<!-- Execute terraform -version -->
- Provider version(s): 1.11
<!-- Execute: terraform providers -version -->

## Reproduction Code [Required]

<!-- REQUIRED -->

Steps to reproduce the behavior:
Run by specifying the module. Hardcoded value is python3.11
```tf
module "notify_slack" {

source  = "terraform-aws-modules/notify-slack/aws"
version = "~> 6.5.0"

runtime = "python3.13"

}
```
OR 

```tf
module "notify_slack" {

source  = "terraform-aws-modules/notify-slack/aws"
version = "~> 6.5.0"

runtime = var.runtime

}
```

`│ Error: Unsupported argument
│
│   on main.tf line 37, in module "notify_slack":
│   37:   runtime                  = var.runtime
│
│ An argument named "runtime" is not expected here.`


<!-- Are you using workspaces? -->
<!-- Have you cleared the local cache (see Notice section above)? -->
<!-- List steps in order that led up to the issue you encountered -->

## Expected behavior
Should be able to update the runtime verison (pythonx.x or nodex.y)
<!-- A clear and concise description of what you expected to happen -->

## Actual behavior

<!-- A clear and concise description of what actually happened -->

### Terminal Output Screenshot(s)

<!-- Optional but helpful -->

## Additional context

Module `terraform-aws-modules/lambda/aws` is accepting `var.runtime`, but not `terraform-aws-modules/notify-slack/aws` module as the runtime is hardcoded 
<!-- Add any other context about the problem here -->
