### PR TITLE
fix: Ensure logger is initialized correctly and propagate `log_level` variable to `LOG_LEVEL` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
 
 ## Supported Features
 
-- AWS Lambda runtime Python 3.11
+- AWS Lambda runtime Python 3.13
 - Create new SNS topic or use existing one
 - Support plaintext and encrypted version of Slack webhook URL
 - Most of Slack message options are customizable
@@ -23,7 +23,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
 ```hcl
 module "notify_slack" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 5.0"
+  version = "~> 7.0"
 
   sns_topic_name = "slack-topic"
 
@@ -122,6 +122,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_lambda_role"></a> [lambda\_role](#input\_lambda\_role) | IAM role attached to the Lambda Function.  If this is set then a role will not be created for you. | `string` | `""` | no |
 | <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | The source path of the custom Lambda function | `string` | `null` | no |
 | <a name="input_log_events"></a> [log\_events](#input\_log\_events) | Boolean flag to enabled/disable logging of incoming events | `bool` | `false` | no |
+| <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Logging level for the Lambda function | `string` | `"INFO"` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -23,6 +23,10 @@ import boto3
 # Set default region if not provided
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 
+# Initialize logging
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
 # Create client so its cached/frozen between invocations
 KMS_CLIENT = boto3.client("kms", region_name=REGION)
 

--- a/main.tf
+++ b/main.tf
@@ -117,6 +117,7 @@ module "lambda" {
     SLACK_USERNAME    = var.slack_username
     SLACK_EMOJI       = var.slack_emoji
     LOG_EVENTS        = var.log_events ? "True" : "False"
+    LOG_LEVEL         = var.log_level
   }
 
   create_role               = var.lambda_role == ""

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,12 @@ variable "log_events" {
   default     = false
 }
 
+variable "log_level" {
+  description = "Logging level for the Lambda function"
+  type        = string
+  default     = "INFO"
+}
+
 variable "reserved_concurrent_executions" {
   description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations"
   type        = number


### PR DESCRIPTION
## Description
- In Lambda function coded added logger initialized with default log level = INFO
- Created dedicated variable to allow users to set lambda log level
- Minor changes to README file

## Motivation and Context
- Resolves #253 

## Breaking Changes
No breaking changes, only fixes and minor improvements.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
