### PR TITLE
feat: Add support for GuardDuty Malware Protection Object Scan Result events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Doing serverless with Terraform? Check out [serverless.tf framework](https://ser
   - AWS CloudWatch Alarms
   - AWS CloudWatch LogMetrics Alarms
   - AWS GuardDuty Findings
+  - AWS GuardDuty Malware Protection Object Scan Results
 
 ## Usage
 

--- a/functions/messages/guardduty_malware_protection_object_scan_result.json
+++ b/functions/messages/guardduty_malware_protection_object_scan_result.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-gov-east-1::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+      "TopicArn": "arn:aws:sns:us-gov-east-1:123456789012:ExampleTopic",
+      "Subject": "GuardDuty Malware Protection Object Scan Result",
+      "Message": "{\"version\":\"0\",\"id\":\"72c7d362-737a-6dce-fc78-9e27a0171419\",\"detail-type\":\"GuardDuty Malware Protection Object Scan Result\",\"source\":\"aws.guardduty\",\"account\":\"111122223333\",\"time\":\"2024-02-28T01:01:01Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:guardduty:us-east-1:111122223333:malware-protection-plan/b4c7f464ab3a4EXAMPLE\"],\"detail\":{\"schemaVersion\":\"1.0\",\"scanStatus\":\"COMPLETED\",\"resourceType\":\"S3_OBJECT\",\"s3ObjectDetails\":{\"bucketName\":\"amzn-s3-demo-bucket\",\"objectKey\":\"APKAEIBAERJR2EXAMPLE\",\"eTag\":\"ASIAI44QH8DHBEXAMPLE\",\"versionId\":\"d41d8cd98f00b204e9800998eEXAMPLE\",\"s3Throttled\":false},\"scanResultDetails\":{\"scanResultStatus\":\"THREATS_FOUND\",\"threats\":[{\"name\":\"EICAR-Test-File (not a virus)\"}]}}}",
+      "Timestamp": "1970-01-01T00:00:00.000Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/functions/snapshots/snap_notify_slack_test.py
+++ b/functions/snapshots/snap_notify_slack_test.py
@@ -602,6 +602,38 @@ snapshots['test_sns_get_slack_message_payload_snapshots message_guardduty_findin
     }
 ]
 
+snapshots['test_sns_get_slack_message_payload_snapshots message_guardduty_malware_protection_object_scan_result.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'danger',
+                'fallback': 'GuardDuty Malware Scan Result: THREATS_FOUND',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'S3 Bucket',
+                        'value': '`amzn-s3-demo-bucket`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'S3 Object',
+                        'value': '`APKAEIBAERJR2EXAMPLE`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Link to S3 object',
+                        'value': 'https://console.aws.amazon.com/s3/object/amzn-s3-demo-bucket?region=us-east-1&prefix=APKAEIBAERJR2EXAMPLE'
+                    }
+                ],
+                'text': 'AWS GuardDuty Malware Scan Result - THREATS_FOUND'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
 snapshots['test_sns_get_slack_message_payload_snapshots message_text_message.json'] = [
     {
         'attachments': [


### PR DESCRIPTION
## Description

For accounts without account-wide GuardDuty, but rather only the S3 Malware Protection, it's nice if we can support notifications for object scan events.

Currently looking like this:
<img width="759" height="290" alt="image" src="https://github.com/user-attachments/assets/8c1ed772-4239-4fee-a51c-5db47dfe912a" />

## Breaking Changes

No breaking changes, only added support for a new event type

## How Has This Been Tested?

- [x] I have tested this on my own AWS account with events set up from GuardDuty