### PR TITLE
fix: Fix parsing of non-JSON messages

### DIFF
--- a/functions/messages/text_message.json
+++ b/functions/messages/text_message.json
@@ -8,7 +8,7 @@
       "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
       "TopicArn": "arn:aws:sns:us-gov-west-1:123456789012:ExampleTopic",
       "Subject": "All Fine",
-      "Message": "This\nis\na typical multi-line\nmessage from SNS!\n\nHave a ~good~ amazing day! :)",
+      "Message": "This\nis\na typical multi-line\ntext-formatted message from SNS!\n\nHave a ~good~ amazing day! :)",
       "Timestamp": "2019-02-12T15:45:24.091Z",
       "SignatureVersion": "1",
       "Signature": "EXAMPLE",

--- a/functions/snapshots/snap_notify_slack_test.py
+++ b/functions/snapshots/snap_notify_slack_test.py
@@ -645,7 +645,7 @@ snapshots['test_sns_get_slack_message_payload_snapshots message_text_message.jso
                         'value': '''This
 is
 a typical multi-line
-message from SNS!
+text-formatted message from SNS!
 
 Have a ~good~ amazing day! :)'''
                     }


### PR DESCRIPTION
## Description

This commit fixes the parsing of messages that aren't JSON-formatted.

In specific, any non-JSON-formatted message that happened to contain the string `"attachments"` or `"text"` was incorrectly treated as a Python dictionary, and failed to parse.

This commit also makes the Python typing a little stricter.

## Motivation and Context

I've left a comment inline below that explains the core fix.

## Breaking Changes

This doesn't break backwards compatibility.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I have tested this in our development AWS env and have confirmed it works.
