### PR TITLE
feat: Add support for Amazon Inspector v2 events

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -111,7 +111,7 @@ Within the Slack channel that is associated to the webhook URL provided, you sho
 
 To add new events with custom message formatting, the general workflow will consist of (ignoring git actions for brevity):
 
-1. Add a new example event paylod to the `functions/events/` directory; please name the file, using snake casing, in the form `<service>_<event_type>.json` such as `guardduty_finding.json` or `cloudwatch_alarm.json`
+1. Add a new example event payload to the `functions/events/` directory; please name the file, using snake casing, in the form `<service>_<event_type>.json` such as `guardduty_finding.json`, `cloudwatch_alarm.json` or `inspector_finding.json`
 2. In the `functions/notify_slack.py` file, add the new formatting function, following a similar naming pattern like in step #1 where the function name is `format_<service>_<event_type>()` such as `format_guardduty_finding()` or `format_cloudwatch_alarm()`
 3. (Optional) Ff there are different "severity" type levels that are to be mapped to Slack message color bars, create an enum that maps the possible serverity values to the appropriate colors. See the `CloudWatchAlarmState` and `GuardDutyFindingSeverity` for examples. The enum name should follow pascal case, Python standard, in the form of `<service><event_type><attribute_field>`
 4. Update the snapshots to include your new event payload and expected output. Note - the other snapshots should not be affected by your change, the snapshot diff should only show your new event:

--- a/functions/events/inspector_finding.json
+++ b/functions/events/inspector_finding.json
@@ -1,0 +1,37 @@
+{
+  "version": "0",
+  "id": "4d621919-f1f4-4201-a0e2-37e4e330ff51",
+  "detail-type": "Inspector2 Finding",
+  "source": "aws.inspector2",
+  "account": "123456789012",
+  "time": "2024-09-04T17:00:36Z",
+  "region": "eu-central-1",
+  "resources": [
+    "i-12345678901234567"
+  ],
+  "detail": {
+    "awsAccountId": "123456789012",
+    "description": "In snapd versions prior to 2.62, snapd failed to properly check the destination of symbolic links when extracting a snap...",
+    "findingArn": "arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID",
+    "firstObservedAt": "Wed Sep 04 16:59:44.356 UTC 2024",
+    "fixAvailable": "YES",
+    "inspectorScore": 4.8,
+    "lastObservedAt": "Wed Sep 04 16:59:44.476 UTC 2024",
+    "packageVulnerabilityDetails": {
+      "vulnerabilityId": "CVE-2024-29069",
+      "vendorSeverity": "medium",
+      "sourceUrl": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-29069.html"
+    },
+    "resources": [
+      {
+        "id": "i-12345678901234567",
+        "type": "AWS_EC2_INSTANCE"
+      }
+    ],
+    "severity": "MEDIUM",
+    "status": "OPEN",
+    "title": "CVE-2024-29069 - snapd",
+    "type": "PACKAGE_VULNERABILITY",
+    "updatedAt": "Wed Sep 04 17:00:36.951 UTC 2024"
+  }
+}

--- a/functions/events/inspector_network_reachability.json
+++ b/functions/events/inspector_network_reachability.json
@@ -1,0 +1,84 @@
+{
+    "version": "0",
+    "id": "9eb1603b-4263-19ec-8be2-33184694cb92",
+    "detail-type": "Inspector2 Finding",
+    "source": "aws.inspector2",
+    "account": "123456789012",
+    "time": "2024-09-05T13:06:56Z",
+    "region": "eu-central-1",
+    "resources": [
+        "i-12345678901234567"
+    ],
+    "detail": {
+        "awsAccountId": "123456789012",
+        "description": "On the instance i-12345678901234567, the port range 22-22 is reachable from the InternetGateway igw-261bab4d from an attached ENI eni-094ad651219472857.",
+        "findingArn": "arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID",
+        "firstObservedAt": "Thu Sep 05 13:06:56.334 UTC 2024",
+        "lastObservedAt": "Thu Sep 05 13:06:56.334 UTC 2024",
+        "networkReachabilityDetails": {
+            "networkPath": {
+                "steps": [
+                    {
+                        "componentId": "igw-261bab4d",
+                        "componentType": "AWS::EC2::InternetGateway"
+                    },
+                    {
+                        "componentId": "acl-171b527d",
+                        "componentType": "AWS::EC2::NetworkAcl"
+                    },
+                    {
+                        "componentId": "sg-0d34debf87410f2d9",
+                        "componentType": "AWS::EC2::SecurityGroup"
+                    },
+                    {
+                        "componentId": "eni-094ad651219472857",
+                        "componentType": "AWS::EC2::NetworkInterface"
+                    },
+                    {
+                        "componentId": "i-12345678901234567",
+                        "componentType": "AWS::EC2::Instance"
+                    }
+                ]
+            },
+            "openPortRange": {
+                "begin": 22,
+                "end": 22
+            },
+            "protocol": "TCP"
+        },
+        "remediation": {
+            "recommendation": {
+                "text": "You can restrict access to your instance by modifying the Security Groups or ACLs in the network path."
+            }
+        },
+        "resources": [
+            {
+                "details": {
+                    "awsEc2Instance": {
+                        "iamInstanceProfileArn": "arn:aws:iam::123456789012:instance-profile/AmazonSSMRoleForInstancesQuickSetup",
+                        "imageId": "ami-02ff980600c693b38",
+                        "ipV4Addresses": [
+                            "1.23.456.789",
+                            "123.45.67.890"
+                        ],
+                        "ipV6Addresses": [],
+                        "launchedAt": "Wed Sep 04 17:41:24.000 UTC 2024",
+                        "platform": "UBUNTU_22_04",
+                        "subnetId": "subnet-12345678",
+                        "type": "t2.small",
+                        "vpcId": "vpc-12345678"
+                    }
+                },
+                "id": "i-12345678901234567",
+                "partition": "aws",
+                "region": "eu-central-1",
+                "type": "AWS_EC2_INSTANCE"
+            }
+        ],
+        "severity": "MEDIUM",
+        "status": "ACTIVE",
+        "title": "Port 22 is reachable from an Internet Gateway - TCP",
+        "type": "NETWORK_REACHABILITY",
+        "updatedAt": "Thu Sep 05 13:06:56.334 UTC 2024"
+    }
+}

--- a/functions/events/inspector_scan.json
+++ b/functions/events/inspector_scan.json
@@ -1,0 +1,23 @@
+{
+    "version": "0",
+    "id": "28a46762-6ac8-6cc4-4f55-bc9ab99af928",
+    "detail-type": "Inspector2 Scan",
+    "source": "aws.inspector2",
+    "account": "111122223333",
+    "time": "2023-01-20T22:52:35Z",
+    "region": "us-east-1",
+    "resources": [
+        "i-087d63509b8c97098"
+    ],
+    "detail": {
+        "scan-status": "INITIAL_SCAN_COMPLETE",
+        "finding-severity-counts": {
+            "CRITICAL": 0,
+            "HIGH": 0,
+            "MEDIUM": 0,
+            "TOTAL": 0
+        },
+        "instance-id": "i-087d63509b8c97098",
+        "version": "1.0"
+    }
+}

--- a/functions/messages/inspector_finding.json
+++ b/functions/messages/inspector_finding.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:eu-central-1::ExampleTopic",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+                "TopicArn": "arn:aws:sns:eu-central-1:123456789012:ExampleTopic",
+                "Subject": "Inspector Finding",
+                "Message": "{\"version\": \"0\", \"id\": \"4d621919-f1f4-4201-a0e2-37e4e330ff51\", \"detail-type\": \"Inspector2 Finding\", \"source\": \"aws.inspector2\", \"account\": \"123456789012\", \"time\": \"2024-09-04T17:00:36Z\", \"region\": \"eu-central-1\", \"resources\": [\"i-12345678901234567\"], \"detail\": {\"awsAccountId\": \"123456789012\", \"description\": \"In snapd versions prior to 2.62, snapd failed to properly check the destination of symbolic links when extracting a snap...\", \"findingArn\": \"arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID\", \"firstObservedAt\": \"Wed Sep 04 16:59:44.356 UTC 2024\", \"fixAvailable\": \"YES\", \"inspectorScore\": 4.8, \"lastObservedAt\": \"Wed Sep 04 16:59:44.476 UTC 2024\", \"packageVulnerabilityDetails\": {\"vulnerabilityId\": \"CVE-2024-29069\", \"vendorSeverity\": \"medium\", \"sourceUrl\": \"https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-29069.html\"}, \"resources\": [{\"id\": \"i-12345678901234567\", \"type\": \"AWS_EC2_INSTANCE\"}], \"severity\": \"MEDIUM\", \"status\": \"OPEN\", \"title\": \"CVE-2024-29069 - snapd\", \"type\": \"PACKAGE_VULNERABILITY\", \"updatedAt\": \"Wed Sep 04 17:00:36.951 UTC 2024\"}}",
+                "Timestamp": "1970-01-01T00:00:00.000Z",
+                "SignatureVersion": "1",
+                "Signature": "EXAMPLE",
+                "SigningCertUrl": "EXAMPLE",
+                "UnsubscribeUrl": "EXAMPLE",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/functions/messages/inspector_network_reachability.json
+++ b/functions/messages/inspector_network_reachability.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:eu-central-1::ExampleTopic",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "9eb1603b-4263-19ec-8be2-33184694cb92",
+                "TopicArn": "arn:aws:sns:eu-central-1:123456789012:ExampleTopic",
+                "Subject": "Inspector Network Finding",
+                "Message": "{\"version\": \"0\", \"id\": \"9eb1603b-4263-19ec-8be2-33184694cb92\", \"detail-type\": \"Inspector2 Finding\", \"source\": \"aws.inspector2\", \"account\": \"123456789012\", \"time\": \"2024-09-05T13:06:56Z\", \"region\": \"eu-central-1\", \"resources\": [\"i-12345678901234567\"], \"detail\": {\"awsAccountId\": \"123456789012\", \"description\": \"On the instance i-12345678901234567, the port range 22-22 is reachable from the InternetGateway igw-261bab4d from an attached ENI eni-094ad651219472857.\", \"findingArn\": \"arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID\", \"firstObservedAt\": \"Thu Sep 05 13:06:56.334 UTC 2024\", \"lastObservedAt\": \"Thu Sep 05 13:06:56.334 UTC 2024\", \"networkReachabilityDetails\": {\"networkPath\": {\"steps\": [{\"componentId\": \"igw-261bab4d\", \"componentType\": \"AWS::EC2::InternetGateway\"}, {\"componentId\": \"acl-171b527d\", \"componentType\": \"AWS::EC2::NetworkAcl\"}, {\"componentId\": \"sg-0d34debf87410f2d9\", \"componentType\": \"AWS::EC2::SecurityGroup\"}, {\"componentId\": \"eni-094ad651219472857\", \"componentType\": \"AWS::EC2::NetworkInterface\"}, {\"componentId\": \"i-12345678901234567\", \"componentType\": \"AWS::EC2::Instance\"}]}, \"openPortRange\": {\"begin\": 22, \"end\": 22}, \"protocol\": \"TCP\"}, \"remediation\": {\"recommendation\": {\"text\": \"You can restrict access to your instance by modifying the Security Groups or ACLs in the network path.\"}}, \"resources\": [{\"details\": {\"awsEc2Instance\": {\"iamInstanceProfileArn\": \"arn:aws:iam::123456789012:instance-profile/AmazonSSMRoleForInstancesQuickSetup\", \"imageId\": \"ami-02ff980600c693b38\", \"ipV4Addresses\": [\"1.23.456.789\", \"123.45.67.890\"], \"ipV6Addresses\": [], \"launchedAt\": \"Wed Sep 04 17:41:24.000 UTC 2024\", \"platform\": \"UBUNTU_22_04\", \"subnetId\": \"subnet-12345678\", \"type\": \"t2.small\", \"vpcId\": \"vpc-12345678\"}}, \"id\": \"i-12345678901234567\", \"partition\": \"aws\", \"region\": \"eu-central-1\", \"type\": \"AWS_EC2_INSTANCE\"}], \"severity\": \"MEDIUM\", \"status\": \"ACTIVE\", \"title\": \"Port 22 is reachable from an Internet Gateway - TCP\", \"type\": \"NETWORK_REACHABILITY\", \"updatedAt\": \"Thu Sep 05 13:06:56.334 UTC 2024\"}}",
+                "Timestamp": "1970-01-01T00:00:00.000Z",
+                "SignatureVersion": "1",
+                "Signature": "EXAMPLE",
+                "SigningCertUrl": "EXAMPLE",
+                "UnsubscribeUrl": "EXAMPLE",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/functions/messages/inspector_scan.json
+++ b/functions/messages/inspector_scan.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1::ExampleTopic",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "28a46762-6ac8-6cc4-4f55-bc9ab99af928",
+                "TopicArn": "arn:aws:sns:us-east-1:111122223333:ExampleTopic",
+                "Subject": "Inspector Scan Result",
+                "Message": "{\"version\": \"0\", \"id\": \"28a46762-6ac8-6cc4-4f55-bc9ab99af928\", \"detail-type\": \"Inspector2 Scan\", \"source\": \"aws.inspector2\", \"account\": \"111122223333\", \"time\": \"2023-01-20T22:52:35Z\", \"region\": \"us-east-1\", \"resources\": [\"i-087d63509b8c97098\"], \"detail\": {\"scan-status\": \"INITIAL_SCAN_COMPLETE\", \"finding-severity-counts\": {\"CRITICAL\": 0, \"HIGH\": 0, \"MEDIUM\": 0, \"TOTAL\": 0}, \"instance-id\": \"i-087d63509b8c97098\", \"version\": \"1.0\"}}",
+                "Timestamp": "1970-01-01T00:00:00.000Z",
+                "SignatureVersion": "1",
+                "Signature": "EXAMPLE",
+                "SigningCertUrl": "EXAMPLE",
+                "UnsubscribeUrl": "EXAMPLE",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -39,6 +39,7 @@ class AwsService(Enum):
     cloudwatch = "cloudwatch"
     guardduty = "guardduty"
     securityhub = "securityhub"
+    inspector2 = "inspector/v2"
 
 
 def decrypt_url(encrypted_url: str) -> str:
@@ -267,6 +268,176 @@ def format_aws_security_hub(message: Dict[str, Any], region: str) -> Dict[str, A
         return slack_message
 
     return format_default(message=message)
+
+
+class InspectorFindingSeverity(Enum):
+    """Maps Amazon Inspector finding severity to Slack message format color"""
+
+    CRITICAL = "danger"
+    HIGH = "danger"
+    MEDIUM = "warning"
+    LOW = "#777777"
+    INFORMATIONAL = "#439FE0"
+
+    @staticmethod
+    def get(name, default):
+        try:
+            return InspectorFindingSeverity[name]
+        except KeyError:
+            return default
+
+
+def format_inspector_finding(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format Amazon Inspector v2 finding event into Slack message format
+
+    :params message: SNS message body containing Inspector finding event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+    service_url = get_service_url(region=region, service="inspector2")
+    detail = message["detail"]
+    severity = detail.get("severity", "INFORMATIONAL")
+    title = detail.get("title", "No Title Provided")
+    description = detail.get("description", "No Description Provided")
+    finding_arn = detail.get("findingArn", "")
+    finding_url = f"{service_url}#/findings/details/{urllib.parse.quote(finding_arn)}"
+
+    first_observed = detail.get("firstObservedAt", "Unknown Date")
+    last_observed = detail.get("lastObservedAt", "Unknown Date")
+    remediation = (
+        detail.get("remediation", {}).get("recommendation", {}).get("text", "N/A")
+    )
+
+    color = InspectorFindingSeverity.get(
+        severity.upper(), InspectorFindingSeverity.INFORMATIONAL
+    ).value
+
+    fields = [
+        {"title": "Title", "value": f"`{title}`", "short": False},
+        {"title": "Description", "value": f"`{description}`", "short": False},
+        {"title": "Severity", "value": f"`{severity}`", "short": True},
+        {
+            "title": "Account ID",
+            "value": f"`{detail.get('awsAccountId', 'Unknown Account')}`",
+            "short": True,
+        },
+        {
+            "title": "Finding Type",
+            "value": f"`{detail.get('type', 'N/A')}`",
+            "short": True,
+        },
+        {
+            "title": "Status",
+            "value": f"`{detail.get('status', 'N/A')}`",
+            "short": True,
+        },
+    ]
+
+    if detail.get("type") == "NETWORK_REACHABILITY":
+        nr_details = detail.get("networkReachabilityDetails", {})
+        protocol = nr_details.get("protocol", "N/A")
+        port_range = nr_details.get("openPortRange", {})
+        begin = port_range.get("begin", "N/A")
+        end = port_range.get("end", "N/A")
+        fields.append({"title": "Protocol", "value": f"`{protocol}`", "short": True})
+        fields.append(
+            {"title": "Port Range", "value": f"`{begin}-{end}`", "short": True}
+        )
+
+    fields.extend(
+        [
+            {"title": "First Observed", "value": f"`{first_observed}`", "short": True},
+            {"title": "Last Observed", "value": f"`{last_observed}`", "short": True},
+            {"title": "Remediation", "value": f"`{remediation}`", "short": False},
+            {"title": "Finding ARN", "value": f"`{finding_arn}`", "short": False},
+            {"title": "Finding Url", "value": f"{finding_url}", "short": False},
+        ]
+    )
+
+    return {
+        "color": color,
+        "fallback": f"Inspector Finding: {title}",
+        "fields": fields,
+        "text": f"Amazon Inspector Finding - {title}",
+    }
+
+
+def format_inspector_scan(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format Amazon Inspector v2 scan result event into Slack message format
+
+    :params message: SNS message body containing Inspector scan event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+    service_url = get_service_url(region=region, service="inspector2")
+    detail = message["detail"]
+    scan_status = detail.get("scan-status", "N/A")
+    instance_id = detail.get("instance-id", "N/A")
+    counts = detail.get("finding-severity-counts", {})
+    critical = counts.get("CRITICAL", 0)
+    high = counts.get("HIGH", 0)
+    medium = counts.get("MEDIUM", 0)
+    total = counts.get("TOTAL", 0)
+
+    if critical > 0 or high > 0:
+        color = InspectorFindingSeverity.CRITICAL.value
+    elif medium > 0:
+        color = InspectorFindingSeverity.MEDIUM.value
+    else:
+        color = InspectorFindingSeverity.INFORMATIONAL.value
+
+    return {
+        "color": color,
+        "fallback": f"Inspector Scan: {scan_status}",
+        "fields": [
+            {"title": "Scan Status", "value": f"`{scan_status}`", "short": True},
+            {"title": "Instance ID", "value": f"`{instance_id}`", "short": True},
+            {"title": "Critical Findings", "value": f"`{critical}`", "short": True},
+            {"title": "High Findings", "value": f"`{high}`", "short": True},
+            {"title": "Medium Findings", "value": f"`{medium}`", "short": True},
+            {"title": "Total Findings", "value": f"`{total}`", "short": True},
+            {"title": "Inspector Console", "value": f"{service_url}", "short": False},
+        ],
+        "text": f"Amazon Inspector Scan Result - {scan_status}",
+    }
+
+
+def format_inspector_coverage(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format Amazon Inspector v2 coverage event into Slack message format
+
+    :params message: SNS message body containing Inspector coverage event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+    service_url = get_service_url(region=region, service="inspector2")
+    detail = message["detail"]
+    scan_status = detail.get("scanStatus", {})
+    status_code = scan_status.get("statusCodeValue", "N/A")
+    reason = scan_status.get("reason", "N/A")
+    scan_type = detail.get("scanType", "N/A")
+    resource = message.get("resources", ["N/A"])[0]
+
+    color = "warning"
+    if status_code == "ACTIVE":
+        color = "good"
+    elif status_code == "INACTIVE":
+        color = "danger"
+
+    return {
+        "color": color,
+        "fallback": f"Inspector Coverage Change: {status_code}",
+        "fields": [
+            {"title": "Status", "value": f"`{status_code}`", "short": True},
+            {"title": "Reason", "value": f"`{reason}`", "short": True},
+            {"title": "Scan Type", "value": f"`{scan_type}`", "short": True},
+            {"title": "Resource", "value": f"`{resource}`", "short": True},
+            {"title": "Inspector Console", "value": f"{service_url}", "short": False},
+        ],
+        "text": f"Amazon Inspector Coverage Change - {resource}",
+    }
 
 
 class SecurityHubSeverity(Enum):
@@ -593,6 +764,12 @@ def parse_notification(message: Dict[str, Any], subject: Optional[str], region: 
         return format_aws_security_hub(message=message, region=message["region"])
     if isinstance(message, Dict) and message.get("detail-type") == "AWS Health Event":
         return format_aws_health(message=message, region=message["region"])
+    if isinstance(message, Dict) and message.get("detail-type") == "Inspector2 Finding":
+        return format_inspector_finding(message=message, region=message["region"])
+    if isinstance(message, Dict) and message.get("detail-type") == "Inspector2 Scan":
+        return format_inspector_scan(message=message, region=message["region"])
+    if isinstance(message, Dict) and message.get("detail-type") == "Inspector2 Coverage":
+        return format_inspector_coverage(message=message, region=message["region"])
     if subject == "Notification from AWS Backup":
         return format_aws_backup(message=str(message))
     return format_default(message=message, subject=subject)

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -139,6 +139,11 @@ def test_environment_variables_missing():
             "guardduty",
             "https://console.amazonaws-us-gov.com/guardduty/home?region=us-gov-east-1",
         ),
+        (
+            "us-east-1",
+            "inspector2",
+            "https://console.aws.amazon.com/inspector/v2/home?region=us-east-1",
+        ),
     ],
 )
 def test_get_service_url(region, service, expected):

--- a/functions/snapshots/snap_notify_slack_test.py
+++ b/functions/snapshots/snap_notify_slack_test.py
@@ -282,6 +282,212 @@ snapshots['test_event_get_slack_message_payload_snapshots event_guardduty_findin
     }
 ]
 
+snapshots['test_event_get_slack_message_payload_snapshots event_inspector_finding.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'warning',
+                'fallback': 'Inspector Finding: CVE-2024-29069 - snapd',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'Title',
+                        'value': '`CVE-2024-29069 - snapd`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`In snapd versions prior to 2.62, snapd failed to properly check the destination of symbolic links when extracting a snap...`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`MEDIUM`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789012`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Finding Type',
+                        'value': '`PACKAGE_VULNERABILITY`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Status',
+                        'value': '`OPEN`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'First Observed',
+                        'value': '`Wed Sep 04 16:59:44.356 UTC 2024`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Last Observed',
+                        'value': '`Wed Sep 04 16:59:44.476 UTC 2024`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Remediation',
+                        'value': '`N/A`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding ARN',
+                        'value': '`arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding Url',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=eu-central-1#/findings/details/arn%3Aaws%3Ainspector2%3Aeu-central-1%3A123456789012%3Afinding/FINDING_ID'
+                    }
+                ],
+                'text': 'Amazon Inspector Finding - CVE-2024-29069 - snapd'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_event_get_slack_message_payload_snapshots event_inspector_network_reachability.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'warning',
+                'fallback': 'Inspector Finding: Port 22 is reachable from an Internet Gateway - TCP',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'Title',
+                        'value': '`Port 22 is reachable from an Internet Gateway - TCP`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`On the instance i-12345678901234567, the port range 22-22 is reachable from the InternetGateway igw-261bab4d from an attached ENI eni-094ad651219472857.`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`MEDIUM`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789012`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Finding Type',
+                        'value': '`NETWORK_REACHABILITY`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Status',
+                        'value': '`ACTIVE`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Protocol',
+                        'value': '`TCP`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Port Range',
+                        'value': '`22-22`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'First Observed',
+                        'value': '`Thu Sep 05 13:06:56.334 UTC 2024`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Last Observed',
+                        'value': '`Thu Sep 05 13:06:56.334 UTC 2024`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Remediation',
+                        'value': '`You can restrict access to your instance by modifying the Security Groups or ACLs in the network path.`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding ARN',
+                        'value': '`arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding Url',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=eu-central-1#/findings/details/arn%3Aaws%3Ainspector2%3Aeu-central-1%3A123456789012%3Afinding/FINDING_ID'
+                    }
+                ],
+                'text': 'Amazon Inspector Finding - Port 22 is reachable from an Internet Gateway - TCP'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_event_get_slack_message_payload_snapshots event_inspector_scan.json'] = [
+    {
+        'attachments': [
+            {
+                'color': '#439FE0',
+                'fallback': 'Inspector Scan: INITIAL_SCAN_COMPLETE',
+                'fields': [
+                    {
+                        'short': True,
+                        'title': 'Scan Status',
+                        'value': '`INITIAL_SCAN_COMPLETE`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Instance ID',
+                        'value': '`i-087d63509b8c97098`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Critical Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'High Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Medium Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Total Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Inspector Console',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=us-east-1'
+                    }
+                ],
+                'text': 'Amazon Inspector Scan Result - INITIAL_SCAN_COMPLETE'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
 snapshots['test_sns_get_slack_message_payload_snapshots message_backup.json'] = [
     {
         'attachments': [
@@ -626,6 +832,212 @@ snapshots['test_sns_get_slack_message_payload_snapshots message_guardduty_malwar
                     }
                 ],
                 'text': 'AWS GuardDuty Malware Scan Result - THREATS_FOUND'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_inspector_finding.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'warning',
+                'fallback': 'Inspector Finding: CVE-2024-29069 - snapd',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'Title',
+                        'value': '`CVE-2024-29069 - snapd`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`In snapd versions prior to 2.62, snapd failed to properly check the destination of symbolic links when extracting a snap...`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`MEDIUM`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789012`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Finding Type',
+                        'value': '`PACKAGE_VULNERABILITY`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Status',
+                        'value': '`OPEN`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'First Observed',
+                        'value': '`Wed Sep 04 16:59:44.356 UTC 2024`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Last Observed',
+                        'value': '`Wed Sep 04 16:59:44.476 UTC 2024`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Remediation',
+                        'value': '`N/A`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding ARN',
+                        'value': '`arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding Url',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=eu-central-1#/findings/details/arn%3Aaws%3Ainspector2%3Aeu-central-1%3A123456789012%3Afinding/FINDING_ID'
+                    }
+                ],
+                'text': 'Amazon Inspector Finding - CVE-2024-29069 - snapd'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_inspector_network_reachability.json'] = [
+    {
+        'attachments': [
+            {
+                'color': 'warning',
+                'fallback': 'Inspector Finding: Port 22 is reachable from an Internet Gateway - TCP',
+                'fields': [
+                    {
+                        'short': False,
+                        'title': 'Title',
+                        'value': '`Port 22 is reachable from an Internet Gateway - TCP`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Description',
+                        'value': '`On the instance i-12345678901234567, the port range 22-22 is reachable from the InternetGateway igw-261bab4d from an attached ENI eni-094ad651219472857.`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Severity',
+                        'value': '`MEDIUM`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Account ID',
+                        'value': '`123456789012`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Finding Type',
+                        'value': '`NETWORK_REACHABILITY`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Status',
+                        'value': '`ACTIVE`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Protocol',
+                        'value': '`TCP`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Port Range',
+                        'value': '`22-22`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'First Observed',
+                        'value': '`Thu Sep 05 13:06:56.334 UTC 2024`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Last Observed',
+                        'value': '`Thu Sep 05 13:06:56.334 UTC 2024`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Remediation',
+                        'value': '`You can restrict access to your instance by modifying the Security Groups or ACLs in the network path.`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding ARN',
+                        'value': '`arn:aws:inspector2:eu-central-1:123456789012:finding/FINDING_ID`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Finding Url',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=eu-central-1#/findings/details/arn%3Aaws%3Ainspector2%3Aeu-central-1%3A123456789012%3Afinding/FINDING_ID'
+                    }
+                ],
+                'text': 'Amazon Inspector Finding - Port 22 is reachable from an Internet Gateway - TCP'
+            }
+        ],
+        'channel': 'slack_testing_sandbox',
+        'icon_emoji': ':aws:',
+        'username': 'notify_slack_test'
+    }
+]
+
+snapshots['test_sns_get_slack_message_payload_snapshots message_inspector_scan.json'] = [
+    {
+        'attachments': [
+            {
+                'color': '#439FE0',
+                'fallback': 'Inspector Scan: INITIAL_SCAN_COMPLETE',
+                'fields': [
+                    {
+                        'short': True,
+                        'title': 'Scan Status',
+                        'value': '`INITIAL_SCAN_COMPLETE`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Instance ID',
+                        'value': '`i-087d63509b8c97098`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Critical Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'High Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Medium Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': True,
+                        'title': 'Total Findings',
+                        'value': '`0`'
+                    },
+                    {
+                        'short': False,
+                        'title': 'Inspector Console',
+                        'value': 'https://console.aws.amazon.com/inspector/v2/home?region=us-east-1'
+                    }
+                ],
+                'text': 'Amazon Inspector Scan Result - INITIAL_SCAN_COMPLETE'
             }
         ],
         'channel': 'slack_testing_sandbox',


### PR DESCRIPTION
## Description
Added support for Amazon Inspector v2 events delivered via EventBridge and SNS.

### Supported Inspector v2 Event Types
This PR adds parsing for the following `aws.inspector2` event types:

*   **Inspector2 Finding**
    *   `PACKAGE_VULNERABILITY`
    *   `NETWORK_REACHABILITY`
*   **Inspector2 Scan**
    *   `INITIAL_SCAN_COMPLETE`

## Motivation and Context
Amazon Inspector v2 emits detailed events via EventBridge that weren't previously being parsed by this module.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have tested this on my own AWS account with events set up from Amazon Inspector v2
- [x] I have executed `pre-commit run -a` on my pull request
- [x] Verified via unit tests and snapshot updates using `pipenv run test:updatesnapshots`