### PR TITLE
fix: Addresses error about inconsistent filexists result in recent terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 8.0.1 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.7.0"
 
   create = var.create
 


### PR DESCRIPTION
## Description

Recent terraform versions require that the fileexists function must return a consistent result in the plan and apply steps. The upstream lambda module was updated to address the error.

See:
* https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/722
* https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/734

Relates: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/271

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
