### PR TITLE
feat: Add support for custom SNS topic policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ See the [functions](https://github.com/terraform-aws-modules/terraform-aws-notif
 | <a name="input_sns_topic_lambda_feedback_role_arn"></a> [sns\_topic\_lambda\_feedback\_role\_arn](#input\_sns\_topic\_lambda\_feedback\_role\_arn) | IAM role for SNS topic delivery status logs.  If this is set then a role will not be created for you. | `string` | `""` | no |
 | <a name="input_sns_topic_lambda_feedback_sample_rate"></a> [sns\_topic\_lambda\_feedback\_sample\_rate](#input\_sns\_topic\_lambda\_feedback\_sample\_rate) | The percentage of successful deliveries to log | `number` | `100` | no |
 | <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | The name of the SNS topic to create | `string` | n/a | yes |
+| <a name="input_sns_topic_policy"></a> [sns\_topic\_policy](#input\_sns\_topic\_policy) | The fully-formed AWS policy as JSON. | `string` | `null` | no |
 | <a name="input_sns_topic_tags"></a> [sns\_topic\_tags](#input\_sns\_topic\_tags) | Additional tags for the SNS topic | `map(string)` | `{}` | no |
 | <a name="input_subscription_filter_policy"></a> [subscription\_filter\_policy](#input\_subscription\_filter\_policy) | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
 | <a name="input_subscription_filter_policy_scope"></a> [subscription\_filter\_policy\_scope](#input\_subscription\_filter\_policy\_scope) | (Optional) A valid filter policy scope MessageAttributes\|MessageBody | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ resource "aws_sns_topic" "this" {
   name = var.sns_topic_name
 
   kms_master_key_id = var.sns_topic_kms_key_id
+  policy            = var.sns_topic_policy
 
   lambda_failure_feedback_role_arn    = var.enable_sns_topic_delivery_status_logs ? local.sns_feedback_role : null
   lambda_success_feedback_role_arn    = var.enable_sns_topic_delivery_status_logs ? local.sns_feedback_role : null

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "sns_topic_kms_key_id" {
   default     = ""
 }
 
+variable "sns_topic_policy" {
+  description = "The fully-formed AWS policy as JSON."
+  type        = string
+  default     = null
+}
+
 variable "enable_sns_topic_delivery_status_logs" {
   description = "Whether to enable SNS topic delivery status logs"
   type        = bool


### PR DESCRIPTION
## Description
Support custom sns_topic_policy (optional)

## Motivation and Context
I trigger the SNS topic using an EventBridge rule; for this to work, we need to configure a custom statement in the SNS access policy.

Resolves #278 

## Breaking Changes
No

## How Has This Been Tested?
I referenced my fork repository
