### PR TITLE
feat: Add service url and s3 object url for AWS China

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -68,6 +68,8 @@ def get_service_url(region: str, service: str) -> str:
         service_name = AwsService[service].value
         if region.startswith("us-gov-"):
             return f"https://console.amazonaws-us-gov.com/{service_name}/home?region={region}"
+        elif region.startswith("cn-"):
+            return f"https://console.amazonaws.cn/{service_name}/home?region={region}"
         else:
             return f"https://console.aws.amazon.com/{service_name}/home?region={region}"
 
@@ -86,6 +88,8 @@ def get_s3_object_url(region: str, bucket: str, key: str) -> str:
     """
     if region.startswith("us-gov-"):
         return f"https://console.amazonaws-us-gov.com/s3/object/{bucket}?region={region}&prefix={key}"
+    elif region.startswith("cn-"):
+        return f"https://{region}.console.amazonaws.cn/s3/object/{bucket}?region={region}&prefix={key}"
     else:
         return f"https://console.aws.amazon.com/s3/object/{bucket}?region={region}&prefix={key}"
 


### PR DESCRIPTION
## Description
Add service url and s3 object url for AWS China

## Motivation and Context
Notifications for workloads in AWS China were building console links incorrectly. 

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
