### PR TITLE
fix: Replace deprecated aws_partition.current.id with .partition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
 
   sns_topic_arn = try(
     aws_sns_topic.this[0].arn,
-    "arn:${data.aws_partition.current.id}:sns:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}",
+    "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}",
     ""
   )
 


### PR DESCRIPTION
## Problem

The `id` attribute on the `aws_partition` data source is deprecated in AWS provider 6.x:

```
Warning: Deprecated attribute

  on .terraform/modules/.../main.tf line 10, in locals:
  10:     "arn:${data.aws_partition.current.id}:sns:...

The attribute "id" is deprecated. Refer to the provider documentation for details.
```

## Fix

Replace `data.aws_partition.current.id` with `data.aws_partition.current.partition`, which is the non-deprecated equivalent and returns the same value (e.g. `aws`, `aws-cn`, `aws-us-gov`).

## Testing

The `partition` attribute has been available on `aws_partition` since early provider versions and returns the same string as `id`. This is a no-op change in behaviour.